### PR TITLE
FromRadio: add QueueStatus payload

### DIFF
--- a/mesh.options
+++ b/mesh.options
@@ -30,6 +30,10 @@
 *MeshPacket.hop_limit int_size:8
 *MeshPacket.channel int_size:8
 
+*QueueStatus.res int_size:8
+*QueueStatus.free int_size:8
+*QueueStatus.maxlen int_size:8
+
 *ToRadio.payload_variant anonymous_oneof:true
 
 *FromRadio.payload_variant anonymous_oneof:true

--- a/mesh.proto
+++ b/mesh.proto
@@ -1166,6 +1166,20 @@ message LogRecord {
   Level level = 4;
 }
 
+message QueueStatus {
+  /* Last attempt to queue status, ErrorCode */
+  int32 res = 1;
+
+  /* Free entries in the outgoing queue */
+  uint32 free = 2;
+
+  /* Maximum entries in the outgoing queue */
+  uint32 maxlen = 3;
+
+  /* What was mesh packet id that generated this response? */
+  uint32 mesh_packet_id = 4;
+}
+
 /*
  * Packets from the radio to the phone will appear on the fromRadio characteristic.
  * It will support READ and NOTIFY. When a new packet arrives the device will BLE notify?
@@ -1237,6 +1251,9 @@ message FromRadio {
      * One packet is sent for each channel
      */
     Channel channel = 10;
+
+    /* Queue status info */
+    QueueStatus queueStatus = 11;
   }
 }
 


### PR DESCRIPTION
Send amount of available places in the queue as well as last allocation result.

## Checklist before merging
- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
- [ ] Formatting is consistent with the defined protolint rules

Signed-off-by: Pavel Boldin <pavel.b@techspark.engineering>
