### PR TITLE
[modules][external notifications] allow select channel to listen to

### DIFF
--- a/module_config.options
+++ b/module_config.options
@@ -4,3 +4,5 @@
 *MQTTConfig.address max_size:32
 *MQTTConfig.username max_size:32
 *MQTTConfig.password max_size:32
+
+*ModuleConfig.ExternalNotificationConfig.bound_channel max_size:200

--- a/module_config.proto
+++ b/module_config.proto
@@ -167,7 +167,10 @@ message ModuleConfig {
      */
     bool alert_bell = 6;
  
-
+    /*
+     * TODO: REPLACE
+     */
+    string bound_channel = 7;
   }
 
   /*


### PR DESCRIPTION
By default external notifications channel is bound to GPIO while canned messages are sent to non-gpio channels essentially making inter-operation between these modules unusable.
Adding this new parameter (with default to old value, so no behavior change) will add ability to change bound channel so listen for bell character/any message on any other channel of choice.