### PR TITLE
Heltec Wireless Stick Lite with ESP32-S3 CPU

### DIFF
--- a/mesh.proto
+++ b/mesh.proto
@@ -363,7 +363,7 @@ enum HardwareModel {
   /*
    * New Heltec Wireless Stick Lite with ESP32-S3 CPU
    */
-   HELTEC_WSL_V3 = 44;
+  HELTEC_WSL_V3 = 44;
   
   /*
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.

--- a/mesh.proto
+++ b/mesh.proto
@@ -359,6 +359,11 @@ enum HardwareModel {
    * New Heltec LoRA32 with ESP32-S3 CPU
    */
   HELTEC_V3 = 43;
+
+  /*
+   * New Heltec Wireless Stick Lite with ESP32-S3 CPU
+   */
+   HELTEC_WSL_V3 = 44;
   
   /*
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.


### PR DESCRIPTION
This can also be used as the "stamp" in custom implementations marketed under the Wireless Shell v3