### PR TITLE
Develop

### DIFF
--- a/config.proto
+++ b/config.proto
@@ -63,7 +63,7 @@ message Config {
      */
     uint32 button_gpio = 4;
 
-        /*
+    /*
      * For boards without a PWM buzzer, this is the pin number that will be used
      * Defaults to PIN_BUZZER if defined.
      */

--- a/config.proto
+++ b/config.proto
@@ -57,6 +57,18 @@ message Config {
      */
     bool debug_log_enabled = 3;
 
+    /*
+     * For boards without a hard wired button, this is the pin number that will be used
+     * Boards that have more than one button can swap the function with this one. defaults to BUTTON_PIN if defined.
+     */
+    uint32 button_gpio = 4;
+
+        /*
+     * For boards without a PWM buzzer, this is the pin number that will be used
+     * Defaults to PIN_BUZZER if defined.
+     */
+    uint32 buzzer_gpio = 5;
+
   }
 
   /*
@@ -174,6 +186,17 @@ message Config {
      * (bitwise OR of PositionFlags)
      */
     uint32 position_flags = 7;
+
+    /*
+     * (Re)define GPS_RX_PIN for your board.
+     */
+    uint32 rx_gpio = 8;
+ 
+    /*
+     * (Re)define GPS_TX_PIN for your board.
+     */
+    uint32 tx_gpio = 9;
+ 
 
   }
 

--- a/module_config.options
+++ b/module_config.options
@@ -2,5 +2,5 @@
 *CannedMessageConfig.messages max_size:200
 
 *MQTTConfig.address max_size:32
-*MQTTConfig.username max_size:32
-*MQTTConfig.password max_size:32
+*MQTTConfig.username max_size:64
+*MQTTConfig.password max_size:64

--- a/module_config.proto
+++ b/module_config.proto
@@ -184,7 +184,6 @@ message ModuleConfig {
 
     /*
      * Preferences for the ExternalNotificationModule
-     * FIXME - Move this out of UserPreferences and into a section for module configuration.
      */
     bool enabled = 1;
 
@@ -212,6 +211,11 @@ message ModuleConfig {
      * TODO: REPLACE
      */
     bool alert_bell = 6;
+
+    /*
+     * TODO: REPLACE
+     */
+    bool use_pwm = 7;
  
 
   }


### PR DESCRIPTION
fix #240
add defines for custom GPIO pins. Kind of 'expert mode' to override board settings and get rid of "potential" pin definitions for boards that don't have a user button or GPS built in.
