### PR TITLE
Develop

### DIFF
--- a/mesh.options
+++ b/mesh.options
@@ -12,13 +12,9 @@
 # note: this payload length is ONLY the bytes that are sent inside of the Data protobuf (excluding protobuf overhead). The 16 byte header is
 # outside of this envelope
 *Data.payload max_size:237
-*Data.payload_compressed max_size:237
-*Data.payload_variant anonymous_oneof:true
 
 # Big enough for 1.2.28.568032c-d
 *MyNodeInfo.firmware_version max_size:18
-
-*MyNodeInfo.region max_size:12
 
 *MyNodeInfo.air_period_tx       max_count:8
 *MyNodeInfo.air_period_rx       max_count:8

--- a/module_config.options
+++ b/module_config.options
@@ -9,3 +9,7 @@
 *AudioConfig.i2s_sd int_size:8
 *AudioConfig.i2s_din int_size:8
 *AudioConfig.i2s_sck int_size:8
+
+*ExternalNotificationConfig.output_vibra int_size 8
+*ExternalNotificationConfig.output_buzzer int_size 8
+*ExternalNotificationConfig.nag_timeout int_size 16

--- a/module_config.options
+++ b/module_config.options
@@ -1,5 +1,4 @@
 *CannedMessageConfig.allow_input_source max_size:16
-*CannedMessageConfig.messages max_size:200
 
 *MQTTConfig.address max_size:32
 *MQTTConfig.username max_size:64

--- a/module_config.options
+++ b/module_config.options
@@ -10,6 +10,6 @@
 *AudioConfig.i2s_din int_size:8
 *AudioConfig.i2s_sck int_size:8
 
-*ExternalNotificationConfig.output_vibra int_size 8
-*ExternalNotificationConfig.output_buzzer int_size 8
-*ExternalNotificationConfig.nag_timeout int_size 16
+*ExternalNotificationConfig.output_vibra int_size:8
+*ExternalNotificationConfig.output_buzzer int_size:8
+*ExternalNotificationConfig.nag_timeout int_size:16

--- a/module_config.proto
+++ b/module_config.proto
@@ -194,41 +194,77 @@ message ModuleConfig {
   message ExternalNotificationConfig {
 
     /*
-     * Preferences for the ExternalNotificationModule
+     * Enable the ExternalNotificationModule
      */
     bool enabled = 1;
 
     /*
-     * TODO: REPLACE
+     * When using in On/Off mode, keep the output on for this many
+     * milliseconds. Default 1000ms (1 second).
      */
     uint32 output_ms = 2;
 
     /*
-     * TODO: REPLACE
+     * Define the output pin GPIO setting Defaults to
+     * EXT_NOTIFY_OUT if set for the board.
+     * In standalone devices this pin should drive the LED to match the UI.
      */
     uint32 output = 3;
 
     /*
-     * TODO: REPLACE
+     * Optional: Define a secondary output pin for a vibra motor
+     * This is used in standalone devices to match the UI.
+     */
+    uint32 output_vibra = 8;
+
+    /*
+     * Optional: Define a tertiary output pin for an active buzzer
+     * This is used in standalone devices to to match the UI.
+     */
+    uint32 output_buzzer = 9;
+
+    /*
+     * IF this is true, the 'output' Pin will be pulled active high, false
+     * means active low.
      */
     bool active = 4;
 
     /*
-     * TODO: REPLACE
+     * True: Alert when a text message arrives (output)
      */
     bool alert_message = 5;
 
     /*
-     * TODO: REPLACE
+     * True: Alert when a text message arrives (output_vibra)
+     */
+    bool alert_message_vibra = 10;
+
+    /*
+     * True: Alert when a text message arrives (output_buzzer)
+     */
+    bool alert_message_buzzer = 11;
+
+    /*
+     * True: Alert when the bell character is received (output)
      */
     bool alert_bell = 6;
 
     /*
-     * TODO: REPLACE
+     * True: Alert when the bell character is received (output_vibra)
+     */
+    bool alert_bell_vibra = 12;
+
+    /*
+     * True: Alert when the bell character is received (output_buzzer)
+     */
+    bool alert_bell_buzzer = 13;
+
+    /*
+     * use a PWM output instead of a simple on/off output. This will ignore
+     * the 'output', 'output_ms' and 'active' settings and use the
+     * device.buzzer_gpio instead.
      */
     bool use_pwm = 7;
- 
-
   }
 
   /*

--- a/module_config.proto
+++ b/module_config.proto
@@ -265,6 +265,13 @@ message ModuleConfig {
      * device.buzzer_gpio instead.
      */
     bool use_pwm = 7;
+
+    /*
+     * The notification will toggle with 'output_ms' for this time of seconds.
+     * Default is 0 which means don't repeat at all. 60 would mean blink
+     * and/or beep for 60 seconds
+     */
+    uint32 nag_timeout = 14;
   }
 
   /*


### PR DESCRIPTION
- remove some unused options the compiler was complaining about
- extend the ExternalNotificationModule to facilitate the 'Meshenger' device.

Note: the verbatim names of the pins (buzzer, vibra) were chosen since there's a bit of UI planned to switch them on and off interactively. This way there's less confusion which define is matched with which menu item.