### PR TITLE
Waypoint types

### DIFF
--- a/mesh.proto
+++ b/mesh.proto
@@ -9,6 +9,7 @@ import "config.proto";
 import "module_config.proto";
 import "portnums.proto";
 import "telemetry.proto";
+import "waypoints.proto";
 
 option java_outer_classname = "MeshProtos";
 option csharp_namespace = "Meshtastic.Protobufs";
@@ -637,10 +638,15 @@ message Waypoint {
    */
   string name = 6;
 
-  /**
+  /*
    * Description of the waypoint - max 100 chars
    */
   string description = 7;
+
+  /*
+   * Type of the waypoint
+   */
+  WaypointType type = 8;
 
 }
 

--- a/waypoints.proto
+++ b/waypoints.proto
@@ -1,0 +1,367 @@
+syntax = "proto3";
+
+option java_package = "com.geeksville.mesh";
+option java_outer_classname = "WaypointType";
+option optimize_for = LITE_RUNTIME;
+option go_package = "github.com/meshtastic/go/generated";
+
+/*
+ * Goal of this type is to provide general categories for Waypoints.
+ * This way an external interface can show them as a special icons.
+ * Therefore maps with waypoints will be a lot easier to understand.
+ * Focus for categories is on navigation, organisation of equipment and special places to know about.
+ *
+ * Categories with 128 entries each:
+ * (The first value in each category is always generic.)
+ *
+ * UNKNOWN:        0
+ * GENERAL-POINTS: 1    - 127
+ * LAND-MARKS:     128  - 255
+ * BUILDINGS:      256  - 383
+ * PLACES:         384  - 511
+ * VEHICLES:       512  - 639
+ * RESSOURCES:     640  - 767
+ */
+enum WaypointType {
+
+  /*
+   * A point that does not fit in other categories
+   */
+  UNKNOWN_WAYPOINT_TYPE = 0;
+
+  /* ----- GENERAL-POINTS ----- */
+
+  /*
+   * Generic waypoint
+   */
+  GENERIC_WAYPOINT = 1;
+
+  /*
+   * Start point
+   */
+  START_POINT = 2;
+
+  /*
+   * Destination
+   */
+  DESTINATION = 3;
+
+  /*
+   * Place to rally / meet
+   */
+  RALLY_POINT = 4;
+
+  /*
+   * Point with great view or to look at
+   */
+  VIEW_POINT = 5;
+
+  /*
+   * Point with dangers
+   */
+  DANGER = 6;
+
+
+
+  /* ----- LAND-MARKS ----- */
+
+  /*
+   * High point, mountain, hill, ...
+   */
+  GENERIC_LAND_MARK = 128;
+
+  /*
+   * High point, mountain, hill, ...
+   */
+  MOUNTAIN = 129;
+
+  /*
+   * River, stream, ...
+   */
+  RIVER = 130;
+
+  /*
+   * Lake, sea, pond,  ...
+   */
+  LAKE = 131;
+
+  /*
+   * Lots of trees
+   */
+  FOREST = 132;
+
+  /*
+   * Rails for trains
+   */
+  RAILS = 133;
+
+  /*
+   * High way, street, ...
+   */
+  STREET = 134;
+
+  /*
+   * Foot path
+   */
+  FOOT_PATH = 135;
+
+  /*
+   * Field
+   */
+  FIELD = 136;
+
+  /*
+   * Valley, Canyon
+   */
+  VALLEY = 137;
+
+  /*
+   * Beach, dessert, ...
+   */
+  SAND = 138;
+
+  /*
+   * Cave
+   */
+  CAVE = 139;
+
+  /*
+   * Vulcan
+   */
+  VULCAN = 140;
+
+  /*
+   * Island
+   */
+  ISLAND = 141;
+
+  /*
+   * Snow and ice
+   */
+  SNOW = 142;
+
+
+
+  /* ----- BUILDINGS ----- */
+
+  /*
+   * General Building
+   */
+  GENERIC_BUILDING = 256;
+
+  /*
+   * Fammily house, Appartment, ...
+   */
+  LIVING_HOUSE = 257;
+
+  /*
+   * Hotel, hostel, ...
+   */
+  HOTEL = 258;
+
+  /*
+   * Doktor, hospital, ...
+   */
+  HOSPITAL = 259;
+
+  /*
+   * First grade, highschool, university, ...
+   */
+  SCHOOL = 260;
+
+  /*
+   * Parlament, town hall, ...
+   */
+  GOVERNMENT_BUILDING = 261;
+
+  /*
+   * Theater, kino, bowling, ...
+   */
+  ACTIVITY_BUILDING = 262;
+
+  /*
+   * Shop, Shopping-Mall, supermarket, ...
+   */
+  SHOP = 263;
+
+  /*
+   * Restaurant, imbiss, fast food, ...
+   */
+  RESTAURANT = 264;
+
+  /*
+   * Gas station
+   */
+  FUEL_STATION = 265;
+
+  /*
+   * Tower for communications
+   */
+  RADIO_TOWER = 266;
+
+  /*
+   * Powerline
+   */
+  POWER_LINE = 267;
+
+  /*
+   * Pipeline for gas, fuel, water, ...
+   */
+  PIPELINE = 268;
+
+  /*
+   * Crossing over water
+   */
+  BRIDGE = 269;
+
+  /*
+   * Post office
+   */
+  POST_OFFICE = 270;
+
+  /*
+   * Train station, bus station, taxi station, airport, ship yard ...
+   */
+  STATION = 271;
+
+  /*
+   * Fence, barbed wire, ...
+   */
+  FENCE = 272;
+
+
+  /* ----- PLACES ----- */
+
+  /*
+   * General place
+   */
+  GENERIC_PLACE = 384;
+
+  /*
+   * Park in town
+   */
+  PARK = 385;
+
+  /*
+   * Open field for public market
+   */
+  MARKET_PLACE = 386;
+
+  /*
+   * Famous building
+   */
+  SIGHT_SEEING = 387;
+
+
+
+  /* ----- VEHICLES ----- */
+
+  /*
+   * General vehicle
+   */
+  GENERIC_VEHICLE = 512;
+
+  /*
+   * Human powered bike
+   */
+  BIKE = 513;
+
+  /*
+   * Motor bike
+   */
+  MOTOR_BIKE = 514;
+
+  /*
+   * Car, Pickup, ...
+   */
+  CAR = 515;
+
+  /*
+   * Bus
+   */
+  BUS = 516;
+
+  /*
+   * Truck
+   */
+  TRUCK = 517;
+
+  /*
+   * Sailboat, Motorboat, Kanu, vehicles in water
+   */
+  SHIP = 518;
+
+  /*
+   * Train, handcar, vehicles on rails
+   */
+  TRAIN = 519;
+
+  /*
+   * Fixed wing aircrafts
+   */
+  PLANE = 520;
+
+  /*
+   * Rotary wing aircrafts
+   */
+  HELICOPTER = 521;
+
+  /*
+   * Military vehicles with armour
+   */
+  TANK = 522;
+
+
+
+  /* ----- RESSOURCES ----- */
+
+  /*
+   * A thing for something else
+   */
+  GENERIC_RESSOURCE = 640;
+
+  /*
+   * Something to drink
+   */
+  WATER = 641;
+
+  /*
+   * Something to eat
+   */
+  FOOD = 642;
+
+  /*
+   * Electricity, battery, ...
+   */
+  ELECTRICITY = 643;
+
+  /*
+   * Something to burn
+   */
+  FUEL = 644;
+
+  /*
+   * Clothes
+   */
+  CLOTHES = 645;
+
+  /*
+   * Handy, Radio, pen & paper, ...
+   */
+  COMMUNICATION_EQUIPMENT = 646;
+
+  /*
+   * Medical supply
+   */
+  MEDICIN = 647;
+
+  /*
+   * Something to sleep in
+   */
+  BED = 648;
+
+  /*
+   * Weapons and ammunition
+   */
+  WEAPONS = 649;
+}

--- a/waypoints.proto
+++ b/waypoints.proto
@@ -92,13 +92,22 @@ enum WaypointType {
   /*
    * Reserved for later use, feel free to find a meaningfull addition
    */
-  RESERVED = 13;
+  RESERVED_0 = 13;
 
   /*
    * Reserved for later use, feel free to find a meaningfull addition
    */
-  RESERVED_2 = 14;
+  RESERVED_1 = 14;
 
+  /*
+   * Reserved for later use, feel free to find a meaningfull addition
+   */
+  RESERVED_2 = 15;
+
+  /*
+   * Reserved for later use, feel free to find a meaningfull addition
+   */
+  RESERVED_3 = 16;
 
 
   /* ----- VEHICLES ----- */
@@ -106,37 +115,32 @@ enum WaypointType {
   /*
    * Bike human or motor powered
    */
-  BIKE = 15;
+  BIKE = 17;
 
   /*
    * Car, Pickup, Bus, Truck ...
    */
-  CAR = 16;
+  CAR = 18;
 
   /*
    * Sailboat, Motorboat, Kanu, vehicles in water
    */
-  SHIP = 17;
+  SHIP = 19;
 
   /*
    * Train, handcar, vehicles on rails
    */
-  TRAIN = 18;
+  TRAIN = 20;
 
   /*
    * Fixed wing aircrafts
    */
-  PLANE = 19;
+  PLANE = 21;
 
   /*
    * Rotary wing aircrafts
    */
-  HELICOPTER = 20;
-
-  /*
-   * Military vehicles with armour
-   */
-  TANK = 21;
+  HELICOPTER = 22;
 
 
 
@@ -145,50 +149,45 @@ enum WaypointType {
   /*
    * A thing for something else
    */
-  GENERIC_RESSOURCE = 22;
+  GENERIC_RESSOURCE = 23;
 
   /*
    * Somebody
    */
-  PERSON = 23;
+  PERSON = 24;
 
   /*
    * Something to drink or eat
    */
-  DRINK_AND_FOOD = 24;
+  DRINK_AND_FOOD = 25;
 
   /*
    * Electricity, battery, ...
    */
-  ELECTRICITY = 25;
+  ELECTRICITY = 26;
 
   /*
    * Something to burn
    */
-  FUEL = 26;
+  FUEL = 27;
 
   /*
    * Clothes
    */
-  CLOTHES = 27;
+  CLOTHES = 28;
 
   /*
    * Handy, Radio, pen & paper, ...
    */
-  COMMUNICATION_EQUIPMENT = 28;
+  COMMUNICATION_EQUIPMENT = 29;
 
   /*
    * Medical supply
    */
-  MEDICIN = 29;
+  MEDICINE = 30;
 
   /*
-   * Something to sleep in
+   * Something or somewhere to sleep in
    */
-  BED = 30;
-
-  /*
-   * Weapons and ammunition
-   */
-  WEAPONS = 31;
+  BED = 31;
 }

--- a/waypoints.proto
+++ b/waypoints.proto
@@ -11,55 +11,34 @@ option go_package = "github.com/meshtastic/go/generated";
  * Therefore maps with waypoints will be a lot easier to understand.
  * Focus for categories is on navigation, organisation of equipment and special places to know about.
  *
- * Categories with 128 entries each:
- * (The first value in each category is always generic.)
- *
- * UNKNOWN:        0
- * GENERAL-POINTS: 1    - 127
- * LAND-MARKS:     128  - 255
- * BUILDINGS:      256  - 383
- * PLACES:         384  - 511
- * VEHICLES:       512  - 639
- * RESSOURCES:     640  - 767
+ * GENERAL-POINTS: 1  - 3
+ * LAND-MARKS:     4  - 14
+ * VEHICLES:       15 - 21
+ * RESSOURCES:     22 - 31
  */
 enum WaypointType {
-
-  /*
-   * A point that does not fit in other categories
-   */
-  UNKNOWN_WAYPOINT_TYPE = 0;
 
   /* ----- GENERAL-POINTS ----- */
 
   /*
    * Generic waypoint
    */
-  GENERIC_WAYPOINT = 1;
-
-  /*
-   * Start point
-   */
-  START_POINT = 2;
-
-  /*
-   * Destination
-   */
-  DESTINATION = 3;
+  GENERIC_WAYPOINT = 0;
 
   /*
    * Place to rally / meet
    */
-  RALLY_POINT = 4;
+  RALLY_POINT = 1;
 
   /*
    * Point with great view or to look at
    */
-  VIEW_POINT = 5;
+  VIEW_POINT = 2;
 
   /*
-   * Point with dangers
+   * Point with dangers, warnings
    */
-  DANGER = 6;
+  DANGER = 3;
 
 
 
@@ -68,248 +47,96 @@ enum WaypointType {
   /*
    * High point, mountain, hill, ...
    */
-  GENERIC_LAND_MARK = 128;
-
-  /*
-   * High point, mountain, hill, ...
-   */
-  MOUNTAIN = 129;
+  MOUNTAIN = 4;
 
   /*
    * River, stream, ...
    */
-  RIVER = 130;
+  RIVER = 5;
 
   /*
    * Lake, sea, pond,  ...
    */
-  LAKE = 131;
+  LAKE = 6;
 
   /*
    * Lots of trees
    */
-  FOREST = 132;
-
-  /*
-   * Rails for trains
-   */
-  RAILS = 133;
-
-  /*
-   * High way, street, ...
-   */
-  STREET = 134;
-
-  /*
-   * Foot path
-   */
-  FOOT_PATH = 135;
+  FOREST = 7;
 
   /*
    * Field
    */
-  FIELD = 136;
+  FIELD = 8;
 
   /*
    * Valley, Canyon
    */
-  VALLEY = 137;
+  VALLEY = 9;
 
   /*
-   * Beach, dessert, ...
+   * City, town, village, ...
    */
-  SAND = 138;
+  CITY = 10;
 
   /*
-   * Cave
+   * Rails for trains, street, bridge ...
    */
-  CAVE = 139;
-
-  /*
-   * Vulcan
-   */
-  VULCAN = 140;
-
-  /*
-   * Island
-   */
-  ISLAND = 141;
-
-  /*
-   * Snow and ice
-   */
-  SNOW = 142;
-
-
-
-  /* ----- BUILDINGS ----- */
+  TRANSPORT_INFRASTRUCTURE = 11;
 
   /*
    * General Building
    */
-  GENERIC_BUILDING = 256;
+  BUILDING = 12;
 
   /*
-   * Fammily house, Appartment, ...
+   * Reserved for later use, feel free to find a meaningfull addition
    */
-  LIVING_HOUSE = 257;
+  RESERVED = 13;
 
   /*
-   * Hotel, hostel, ...
+   * Reserved for later use, feel free to find a meaningfull addition
    */
-  HOTEL = 258;
-
-  /*
-   * Doktor, hospital, ...
-   */
-  HOSPITAL = 259;
-
-  /*
-   * First grade, highschool, university, ...
-   */
-  SCHOOL = 260;
-
-  /*
-   * Parlament, town hall, ...
-   */
-  GOVERNMENT_BUILDING = 261;
-
-  /*
-   * Theater, kino, bowling, ...
-   */
-  ACTIVITY_BUILDING = 262;
-
-  /*
-   * Shop, Shopping-Mall, supermarket, ...
-   */
-  SHOP = 263;
-
-  /*
-   * Restaurant, imbiss, fast food, ...
-   */
-  RESTAURANT = 264;
-
-  /*
-   * Gas station
-   */
-  FUEL_STATION = 265;
-
-  /*
-   * Tower for communications
-   */
-  RADIO_TOWER = 266;
-
-  /*
-   * Powerline
-   */
-  POWER_LINE = 267;
-
-  /*
-   * Pipeline for gas, fuel, water, ...
-   */
-  PIPELINE = 268;
-
-  /*
-   * Crossing over water
-   */
-  BRIDGE = 269;
-
-  /*
-   * Post office
-   */
-  POST_OFFICE = 270;
-
-  /*
-   * Train station, bus station, taxi station, airport, ship yard ...
-   */
-  STATION = 271;
-
-  /*
-   * Fence, barbed wire, ...
-   */
-  FENCE = 272;
-
-
-  /* ----- PLACES ----- */
-
-  /*
-   * General place
-   */
-  GENERIC_PLACE = 384;
-
-  /*
-   * Park in town
-   */
-  PARK = 385;
-
-  /*
-   * Open field for public market
-   */
-  MARKET_PLACE = 386;
-
-  /*
-   * Famous building
-   */
-  SIGHT_SEEING = 387;
+  RESERVED_2 = 14;
 
 
 
   /* ----- VEHICLES ----- */
 
   /*
-   * General vehicle
+   * Bike human or motor powered
    */
-  GENERIC_VEHICLE = 512;
+  BIKE = 15;
 
   /*
-   * Human powered bike
+   * Car, Pickup, Bus, Truck ...
    */
-  BIKE = 513;
-
-  /*
-   * Motor bike
-   */
-  MOTOR_BIKE = 514;
-
-  /*
-   * Car, Pickup, ...
-   */
-  CAR = 515;
-
-  /*
-   * Bus
-   */
-  BUS = 516;
-
-  /*
-   * Truck
-   */
-  TRUCK = 517;
+  CAR = 16;
 
   /*
    * Sailboat, Motorboat, Kanu, vehicles in water
    */
-  SHIP = 518;
+  SHIP = 17;
 
   /*
    * Train, handcar, vehicles on rails
    */
-  TRAIN = 519;
+  TRAIN = 18;
 
   /*
    * Fixed wing aircrafts
    */
-  PLANE = 520;
+  PLANE = 19;
 
   /*
    * Rotary wing aircrafts
    */
-  HELICOPTER = 521;
+  HELICOPTER = 20;
 
   /*
    * Military vehicles with armour
    */
-  TANK = 522;
+  TANK = 21;
 
 
 
@@ -318,50 +145,50 @@ enum WaypointType {
   /*
    * A thing for something else
    */
-  GENERIC_RESSOURCE = 640;
+  GENERIC_RESSOURCE = 22;
 
   /*
-   * Something to drink
+   * Somebody
    */
-  WATER = 641;
+  PERSON = 23;
 
   /*
-   * Something to eat
+   * Something to drink or eat
    */
-  FOOD = 642;
+  DRINK_AND_FOOD = 24;
 
   /*
    * Electricity, battery, ...
    */
-  ELECTRICITY = 643;
+  ELECTRICITY = 25;
 
   /*
    * Something to burn
    */
-  FUEL = 644;
+  FUEL = 26;
 
   /*
    * Clothes
    */
-  CLOTHES = 645;
+  CLOTHES = 27;
 
   /*
    * Handy, Radio, pen & paper, ...
    */
-  COMMUNICATION_EQUIPMENT = 646;
+  COMMUNICATION_EQUIPMENT = 28;
 
   /*
    * Medical supply
    */
-  MEDICIN = 647;
+  MEDICIN = 29;
 
   /*
    * Something to sleep in
    */
-  BED = 648;
+  BED = 30;
 
   /*
    * Weapons and ammunition
    */
-  WEAPONS = 649;
+  WEAPONS = 31;
 }


### PR DESCRIPTION
Add a type to waypoints.

## What does this PR do?
This PR provides a list of types for waypoints. This way specific icons can be used to make maps with waypoints more readable and easier to understand.
With this feature it will be possible to implement a filter system for waypoint types.

Please double check. I never worked before with protobufs.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
- [x] Formatting is consistant with the defined protolint rules
