### PR TITLE
fix connection_status java_outer_classname

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "AdminProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/apponly.proto
+++ b/meshtastic/apponly.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "AppOnlyProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/cannedmessages.proto
+++ b/meshtastic/cannedmessages.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "CannedMessageConfigProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/channel.proto
+++ b/meshtastic/channel.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "ChannelProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "ConfigProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/connection_status.proto
+++ b/meshtastic/connection_status.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "ConnStatusProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/connection_status.proto
+++ b/meshtastic/connection_status.proto
@@ -4,7 +4,7 @@ package meshtastic;
 
 option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
-option java_outer_classname = "ConfigProtos";
+option java_outer_classname = "ConnStatusProtos";
 option go_package = "github.com/meshtastic/go/generated";
 option csharp_namespace = "Meshtastic.Protobufs";
 option swift_prefix = "";

--- a/meshtastic/device_metadata.proto
+++ b/meshtastic/device_metadata.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "DeviceMetadataProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "DeviceOnly";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/localonly.proto
+++ b/meshtastic/localonly.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "LocalOnlyProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "MeshProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "ModuleConfigProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/mqtt.proto
+++ b/meshtastic/mqtt.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "MQTTProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "Portnums";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/remote_hardware.proto
+++ b/meshtastic/remote_hardware.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "RemoteHardware";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/rtttl.proto
+++ b/meshtastic/rtttl.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "RTTTLConfigProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/storeforward.proto
+++ b/meshtastic/storeforward.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "StoreAndForwardProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "TelemetryProtos";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/xmodem.proto
+++ b/meshtastic/xmodem.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package meshtastic;
 
-option optimize_for = LITE_RUNTIME;
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "XmodemProtos";
 option go_package = "github.com/meshtastic/go/generated";


### PR DESCRIPTION
- fix connection_status.proto `java_outer_classname`
- remove deprecated "_optimize_for = LITE_RUNTIME_"