### PR TITLE
Added configurable node info interval

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -115,7 +115,7 @@ message Config {
 
     /*
      * Send our nodeinfo this often
-     * Defaults to 15 minutes
+     * Defaults to 900 Seconds (15 minutes)
      */
     uint32 node_info_broadcast_secs = 7;
   }

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -117,7 +117,7 @@ message Config {
      * Send our nodeinfo this often
      * Defaults to 15 minutes
      */
-    uint32 node_info_broadcast_secs = 1;
+    uint32 node_info_broadcast_secs = 7;
   }
 
   /*

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -112,6 +112,12 @@ message Config {
      * Sets the role of node
      */
     RebroadcastMode rebroadcast_mode = 6;
+
+    /*
+     * Send our nodeinfo this often
+     * Defaults to 15 minutes
+     */
+    uint32 node_info_broadcast_secs = 1;
   }
 
   /*


### PR DESCRIPTION
Needed to be done a long time ago, but we _really_ need it to satisfy the FCC's callsign announcement interval policy of stations identifying themselves at least every 10 minutes