### PR TITLE
add channel to NodeInfo

### DIFF
--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -13,6 +13,8 @@
 # outside of this envelope
 *Data.payload max_size:237
 
+*NodeInfo.channel int_size:8
+
 # Big enough for 1.2.28.568032c-d
 *MyNodeInfo.firmware_version max_size:18
 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -977,7 +977,7 @@ message NodeInfo {
   DeviceMetrics device_metrics = 6;
 
   /*
-   * local channel we heared that node
+   * local channel index we heard that node on. Only populated if its not the default channel.
    */
   uint32 channel = 7;
 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -975,6 +975,12 @@ message NodeInfo {
    * The latest device metrics for the node.
    */
   DeviceMetrics device_metrics = 6;
+
+  /*
+   * local channel we heared that node
+   */
+  uint32 channel = 7;
+
 }
 
 /*


### PR DESCRIPTION
Add channel to NodeInfo to reach nodes directly that are not listening on out primary channel
 
## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
