### PR TITLE
Clientonly protobufs as a device profile contract

### DIFF
--- a/meshtastic/clientonly.options
+++ b/meshtastic/clientonly.options
@@ -1,0 +1,3 @@
+*DeviceProfile.channels max_count:8
+*DeviceProfile.long_name max_size:40
+*DeviceProfile.short_name max_size:5

--- a/meshtastic/clientonly.options
+++ b/meshtastic/clientonly.options
@@ -1,3 +1,2 @@
-*DeviceProfile.channels max_count:8
 *DeviceProfile.long_name max_size:40
 *DeviceProfile.short_name max_size:5

--- a/meshtastic/clientonly.proto
+++ b/meshtastic/clientonly.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package meshtastic;
+
+option java_package = "com.geeksville.mesh";
+option java_outer_classname = "ClientOnlyProtos";
+option go_package = "github.com/meshtastic/go/generated";
+option csharp_namespace = "Meshtastic.Protobufs";
+option swift_prefix = "";
+
+
+import "meshtastic/channel.proto";
+import "meshtastic/localonly.proto";
+
+/*
+ * This abstraction is used to contain any configuration for provisioning a node on any client.
+ * It is useful for importing and exporting configurations.
+ */
+message DeviceProfile {
+  /*
+   * Long name for the node
+   */
+  optional string long_name = 1;
+
+  /*
+   * Short name of the node
+   */
+  optional string short_name = 2;
+
+  /*
+   * The channels our node knows about
+   */
+  repeated Channel channels = 3;
+
+  /*
+   * The Config of the node
+   */
+  optional LocalConfig config = 4;
+
+  /*
+   * The ModuleConfig of the node
+   */
+  optional LocalModuleConfig module_config = 5;
+}

--- a/meshtastic/clientonly.proto
+++ b/meshtastic/clientonly.proto
@@ -28,9 +28,9 @@ message DeviceProfile {
   optional string short_name = 2;
 
   /*
-   * The channels our node knows about
+   * The url of the channels from our node
    */
-  repeated Channel channels = 3;
+  optional string channel_url = 3;
 
   /*
    * The Config of the node

--- a/meshtastic/clientonly.proto
+++ b/meshtastic/clientonly.proto
@@ -9,7 +9,6 @@ option csharp_namespace = "Meshtastic.Protobufs";
 option swift_prefix = "";
 
 
-import "meshtastic/channel.proto";
 import "meshtastic/localonly.proto";
 
 /*


### PR DESCRIPTION
This would allow clients to share a common strongly typed data structure for serializing / deserializing a device profile (names, channels, config, module config) so that it can be consistently used across platforms. 
I'm working on the export functionality as yaml in the C# cli currently.