### PR TITLE
CalTopo serial mode

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -177,6 +177,8 @@ message ModuleConfig {
       PROTO = 2;
       TEXTMSG = 3;
       NMEA = 4;
+      // NMEA messages specifically tailored for CalTopo
+      CALTOPO = 5;
     }
 
     /*


### PR DESCRIPTION
In working on the CalTopo (APRS) integration, I discovered some _quirks_ about how they accept NMEA sentences that we'll have to work around by using this custom mode. 
I will be sending a note to their engineers to hopefully enhance their support by removing some of the limitations 