### PR TITLE
Deprecate MyNodeInfo fields: max_channels, message_timeout_msec, has_wifi, channel_utilization, and air_util_tx

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1120,14 +1120,16 @@ message MyNodeInfo {
   uint32 min_app_version = 11;
 
   /*
+   * Deprecated in 2.1.x (Only used on device to keep track of utilization)
    * 24 time windows of 1hr each with the airtime transmitted out of the device per hour.
    */
-  repeated uint32 air_period_tx = 12;
+  repeated uint32 air_period_tx = 12 [deprecated = true];
 
   /*
+   * Deprecated in 2.1.x (Only used on device to keep track of utilization)
    * 24 time windows of 1hr each with the airtime of valid packets for your mesh.
    */
-  repeated uint32 air_period_rx = 13;
+  repeated uint32 air_period_rx = 13 [deprecated = true];
 
   /*
    * Deprecated in 2.1.x (Source from DeviceMetadata instead)

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -448,10 +448,11 @@ message User {
   string short_name = 3;
 
   /*
+   * Deprecated in Meshtastic 2.1.x
    * This is the addr of the radio.
    * Not populated by the phone, but added by the esp32 when broadcasting
    */
-  bytes macaddr = 4;
+  bytes macaddr = 4 [deprecated = true];
 
   /*
    * TBEAM, HELTEC, etc...

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1114,11 +1114,10 @@ message MyNodeInfo {
   uint32 message_timeout_msec = 10 [deprecated = true];
 
   /*
-   * Deprecated in 2.1.x
    * The minimum app version that can talk to this device.
    * Phone/PC apps should compare this to their build number and if too low tell the user they must update their app
    */
-  uint32 min_app_version = 11 [deprecated = true];
+  uint32 min_app_version = 11;
 
   /*
    * 24 time windows of 1hr each with the airtime transmitted out of the device per hour.
@@ -1137,14 +1136,16 @@ message MyNodeInfo {
   bool has_wifi = 14 [deprecated = true];
 
   /*
+   * Deprecated in 2.1.x (Source from DeviceMetrics telemetry payloads)
    * Utilization for the current channel, including well formed TX, RX and malformed RX (aka noise).
    */
-  float channel_utilization = 15;
+  float channel_utilization = 15 [deprecated = true];
 
   /*
+   * Deprecated in 2.1.x (Source from DeviceMetrics telemetry payloads)
    * Percent of airtime for transmission used within the last hour.
    */
-  float air_util_tx = 16;
+  float air_util_tx = 16 [deprecated = true];
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1117,7 +1117,7 @@ message MyNodeInfo {
    * The minimum app version that can talk to this device.
    * Phone/PC apps should compare this to their build number and if too low tell the user they must update their app
    */
-  uint32 min_app_version = 11;
+  uint32 min_app_version = 11 [deprecated = true];
 
   /*
    * 24 time windows of 1hr each with the airtime transmitted out of the device per hour.

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1062,9 +1062,10 @@ message MyNodeInfo {
   bool has_gps = 2;
 
   /*
+   * Deprecated in 2.1.x
    * The maximum number of 'software' channels that can be set on this node.
    */
-  uint32 max_channels = 3;
+  uint32 max_channels = 3 [deprecated = true];
 
   /*
    * 0.0.5 etc...

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1114,6 +1114,7 @@ message MyNodeInfo {
   uint32 message_timeout_msec = 10 [deprecated = true];
 
   /*
+   * Deprecated in 2.1.x
    * The minimum app version that can talk to this device.
    * Phone/PC apps should compare this to their build number and if too low tell the user they must update their app
    */

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1105,12 +1105,13 @@ message MyNodeInfo {
   float bitrate = 9;
 
   /*
+   * Deprecated in 2.1.x
    * How long before we consider a message abandoned and we can clear our
    * caches of any messages in flight Normally quite large to handle the worst case
    * message delivery time, 5 minutes.
    * Formerly called FLOOD_EXPIRE_TIME in the device code
    */
-  uint32 message_timeout_msec = 10;
+  uint32 message_timeout_msec = 10 [deprecated = true];
 
   /*
    * The minimum app version that can talk to this device.
@@ -1129,9 +1130,10 @@ message MyNodeInfo {
   repeated uint32 air_period_rx = 13;
 
   /*
+   * Deprecated in 2.1.x (Source from DeviceMetadata instead)
    * Is the device wifi capable?
    */
-  bool has_wifi = 14;
+  bool has_wifi = 14 [deprecated = true];
 
   /*
    * Utilization for the current channel, including well formed TX, RX and malformed RX (aka noise).


### PR DESCRIPTION
max_channels: No sense in keeping something that is always hardcoded to 8 in the firmware anyway and macro is used instead
message_timeout_msec: Initialized to a macro value and then the macro value is used everywhere in the codebase 🙄 
has_wifi: This should be sourced from devicemetadata.haswifi now (which also comes up on want_config)