### PR TITLE
Removing Portnum we didn't actually use

### DIFF
--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -85,11 +85,6 @@ enum PortNum {
   AUDIO_APP = 9;
 
   /*
-   * Payloads for clients with a network connection proxying MQTT pub/sub to the device
-   */
-  MQTT_CLIENT_PROXY_APP = 10;
-
-  /*
    * Provides a 'ping' service that replies to any packet it receives.
    * Also serves as a small example module.
    */


### PR DESCRIPTION
We never use this portnum, because MqttClientProxyMessages exist on FromRadio and ToRadio instead of a MeshPacket