### PR TITLE
2.2.X Proposed Protobuf changes

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -109,6 +109,11 @@ message AdminMessage {
      * TODO: REPLACE
      */
     REMOTEHARDWARE_CONFIG = 8;
+
+    /*
+     * TODO: REPLACE
+     */
+    NEIGHBORINFO_CONFIG = 9;
   }
 
   /*

--- a/meshtastic/channel.proto
+++ b/meshtastic/channel.proto
@@ -27,6 +27,11 @@ option swift_prefix = "";
  */
 message ChannelSettings {
   /*
+   * Deprecated in favor of LoraConfig.channel_num
+   */
+  uint32 channel_num = 1 [deprecated = true];
+
+  /*
    * A simple pre-shared key for now for crypto.
    * Must be either 0 bytes (no crypto), 16 bytes (AES128), or 32 bytes (AES256).
    * A special shorthand is used for 1 byte long psks.

--- a/meshtastic/channel.proto
+++ b/meshtastic/channel.proto
@@ -27,11 +27,6 @@ option swift_prefix = "";
  */
 message ChannelSettings {
   /*
-   * Deprecated in favor of LoraConfig.channel_num
-   */
-  uint32 channel_num = 1 [deprecated = true];
-
-  /*
    * A simple pre-shared key for now for crypto.
    * Must be either 0 bytes (no crypto), 16 bytes (AES128), or 32 bytes (AES256).
    * A special shorthand is used for 1 byte long psks.

--- a/meshtastic/deviceonly.options
+++ b/meshtastic/deviceonly.options
@@ -2,7 +2,6 @@
 # https://jpa.kapsi.fi/nanopb/docs/reference.html#proto-file-options
 
 # FIXME pick a higher number someday? or do dynamic alloc in nanopb?
-*DeviceState.node_db max_count:80
 *DeviceState.node_db_lite max_count:80
 
 # FIXME - max_count is actually 32 but we save/load this as one long string of preencoded MeshPacket bytes - not a big array in RAM

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -33,12 +33,6 @@ message DeviceState {
   User owner = 3;
 
   /*
-   * Deprecated in 2.1.x
-   * Old node_db. See NodeInfoLite node_db_lite
-   */
-  repeated NodeInfo node_db = 4 [deprecated = true];
-
-  /*
    * Received packets saved for delivery to the phone
    */
   repeated MeshPacket receive_queue = 5;

--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -52,7 +52,6 @@
 *Waypoint.description  max_size:100
 
 *NeighborInfo.neighbors max_count:10
-*Neighbor.node_broadcast_interval_secs int_size:16
 
 *DeviceMetadata.firmware_version max_size:18
 

--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -52,6 +52,7 @@
 *Waypoint.description  max_size:100
 
 *NeighborInfo.neighbors max_count:10
+*Neighbor.node_broadcast_interval_secs max_size:16
 
 *DeviceMetadata.firmware_version max_size:18
 

--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -52,7 +52,7 @@
 *Waypoint.description  max_size:100
 
 *NeighborInfo.neighbors max_count:10
-*Neighbor.node_broadcast_interval_secs max_size:16
+*Neighbor.node_broadcast_interval_secs int_size:16
 
 *DeviceMetadata.firmware_version max_size:18
 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1366,10 +1366,15 @@ message NeighborInfo {
    * Field to pass neighbor info for the next sending cycle
    */
   uint32 last_sent_by_id = 2;
+
+  /*
+   * Broadcast interval of the represented node (in seconds)
+   */
+  uint32 node_broadcast_interval_secs = 3;
   /*
    * The list of out edges from this node
    */
-  repeated Neighbor neighbors = 3;
+  repeated Neighbor neighbors = 4;
 }
 
 /*
@@ -1385,11 +1390,6 @@ message Neighbor {
    * SNR of last heard message
    */
   float snr = 2;
-
-  /*
-   * Broadcast interval of the represented node (in seconds)
-   */
-  uint32 node_broadcast_interval_secs = 3;
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1385,6 +1385,11 @@ message Neighbor {
    * SNR of last heard message
    */
   float snr = 2;
+
+  /*
+   * Broadcast interval of the represented node (in seconds)
+   */
+  uint32 node_broadcast_interval_secs = 3;
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1106,101 +1106,16 @@ message MyNodeInfo {
   uint32 my_node_num = 1;
 
   /*
-   * Deprecated in 2.1.x (Source from device_metadata)
-   * Note: This flag merely means we detected a hardware GPS in our node.
-   * Not the same as UserPreferences.location_sharing
-   */
-  bool has_gps = 2 [deprecated = true];
-
-  /*
-   * Deprecated in 2.1.x
-   * The maximum number of 'software' channels that can be set on this node.
-   */
-  uint32 max_channels = 3 [deprecated = true];
-
-  /*
-   * Deprecated in 2.1.x (Source from device_metadata)
-   * 0.0.5 etc...
-   */
-  string firmware_version = 4 [deprecated = true];
-
-  /*
-   * An error message we'd like to report back to the mothership through analytics.
-   * It indicates a serious bug occurred on the device, the device coped with it,
-   * but we still want to tell the devs about the bug.
-   * This field will be cleared after the phone reads MyNodeInfo
-   * (i.e. it will only be reported once)
-   * a numeric error code to go with error message, zero means no error
-   */
-  CriticalErrorCode error_code = 5 [deprecated = true];
-
-  /*
-   * A numeric error address (nonzero if available)
-   */
-  uint32 error_address = 6 [deprecated = true];
-
-  /*
-   * The total number of errors this node has ever encountered
-   * (well - since the last time we discarded preferences)
-   */
-  uint32 error_count = 7 [deprecated = true];
-
-  /*
    * The total number of reboots this node has ever encountered
    * (well - since the last time we discarded preferences)
    */
   uint32 reboot_count = 8;
 
   /*
-   * Deprecated in 2.1.x
-   * Calculated bitrate of the current channel (in Bytes Per Second)
-   */
-  float bitrate = 9 [deprecated = true];
-
-  /*
-   * Deprecated in 2.1.x
-   * How long before we consider a message abandoned and we can clear our
-   * caches of any messages in flight Normally quite large to handle the worst case
-   * message delivery time, 5 minutes.
-   * Formerly called FLOOD_EXPIRE_TIME in the device code
-   */
-  uint32 message_timeout_msec = 10 [deprecated = true];
-
-  /*
    * The minimum app version that can talk to this device.
    * Phone/PC apps should compare this to their build number and if too low tell the user they must update their app
    */
   uint32 min_app_version = 11;
-
-  /*
-   * Deprecated in 2.1.x (Only used on device to keep track of utilization)
-   * 24 time windows of 1hr each with the airtime transmitted out of the device per hour.
-   */
-  repeated uint32 air_period_tx = 12 [deprecated = true];
-
-  /*
-   * Deprecated in 2.1.x (Only used on device to keep track of utilization)
-   * 24 time windows of 1hr each with the airtime of valid packets for your mesh.
-   */
-  repeated uint32 air_period_rx = 13 [deprecated = true];
-
-  /*
-   * Deprecated in 2.1.x (Source from DeviceMetadata instead)
-   * Is the device wifi capable?
-   */
-  bool has_wifi = 14 [deprecated = true];
-
-  /*
-   * Deprecated in 2.1.x (Source from DeviceMetrics telemetry payloads)
-   * Utilization for the current channel, including well formed TX, RX and malformed RX (aka noise).
-   */
-  float channel_utilization = 15 [deprecated = true];
-
-  /*
-   * Deprecated in 2.1.x (Source from DeviceMetrics telemetry payloads)
-   * Percent of airtime for transmission used within the last hour.
-   */
-  float air_util_tx = 16 [deprecated = true];
 }
 
 /*


### PR DESCRIPTION
On the device, we will incremement the DEVICESTATE_VERSION, so folks will need to re-provision their devices. This also gives you all on the app / client front a clean slate. Most of this is removing, _not re-indexing_ deprecated protobufs. We'll save re-indexing for 3.0, since that will be a breaking change for the protocol. Clients need to source some of the removed fields from MyNodeInfo on DeviceMetadata now

This shouldn't be a breaking change, per-se except for the device which as I mentioned will incremement the DEVICESTATE_VERSION and reprovision.  Some clients may respond differently to the removal of protobuf fields, so I'm not entirely sure how that looks in each one. In any account, apps / clients will need to do the minimum version prompt when attempting to pair 2.0/2.1x devices to ensure that things move forward. I think it should be a pretty smooth transition. 

If it doesn't work out on the field removal front in MyNodeInfo, we can go back on that. My preference was to remove those before 3.0, to slowly transition to phasing those fields out rather than completely gutting like we did from 1.2 to 2.0, which placed a large burden on all of the clients.