### PR TITLE
Transmit broadcasting interval for neighbors

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1477,7 +1477,7 @@ message Neighbor {
   float snr = 2;
 
   /*
-   * Broadcast interval of the represented node
+   * Broadcast interval of the represented node (in seconds)
    */
   uint16 node_broadcast_interval = 3;
 }

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1475,6 +1475,11 @@ message Neighbor {
    * SNR of last heard message
    */
   float snr = 2;
+
+  /*
+   * Broadcast interval of the represented node
+   */
+  uint16 node_broadcast_interval = 3;
 }
 
 /*


### PR DESCRIPTION
# What does this PR do?

Currently devices and clients are unable to know the duration at which other nodes broadcasting neighbor information packets. This PR adds in a field to allow devices to know exactly how often it should expect to hear from each neighbor.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
