### PR TITLE
Fix unmappable character (0x98) for encoding windows-1251 #373

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -750,9 +750,9 @@ message MeshPacket {
    * to make sure that critical packets are sent ASAP.
    * In the case of meshtastic that means we want to send protocol acks as soon as possible
    * (to prevent unneeded retransmissions), we want routing messages to be sent next,
-   * then messages marked as reliable and finally ‘background’ packets like periodic position updates.
+   * then messages marked as reliable and finally 'background' packets like periodic position updates.
    * So I bit the bullet and implemented a new (internal - not sent over the air)
-   * field in MeshPacket called ‘priority’.
+   * field in MeshPacket called 'priority'.
    * And the transmission queue in the router object is now a priority queue.
    */
   enum Priority {


### PR DESCRIPTION
Fix unmappable character (0x98) for encoding windows-1251

# What does this PR do?

> [Related Issue](https://github.com/meshtastic/protobufs/issues/373)

## Checklist before merging

- [X] All top level messages commented
- [X] All enum members have unique descriptions
