### PR TITLE
New Detection Sensor module for messaging the mesh on detected state changes

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -119,6 +119,11 @@ message AdminMessage {
      * TODO: REPLACE
      */
     AMBIENTLIGHTING_CONFIG = 10;
+
+    /*
+     * TODO: REPLACE
+     */
+    DETECTION_CONFIG = 11;
   }
 
   /*

--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -123,7 +123,7 @@ message AdminMessage {
     /*
      * TODO: REPLACE
      */
-    DETECTION_CONFIG = 11;
+    DETECTIONSENSOR_CONFIG = 11;
   }
 
   /*

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -268,7 +268,7 @@ message Config {
     uint32 broadcast_smart_minimum_distance = 10;
 
     /*
-     * The minumum number of seconds (since the last send) before we can send a position to the mesh if position_broadcast_smart_enabled
+     * The minimum number of seconds (since the last send) before we can send a position to the mesh if position_broadcast_smart_enabled
      */
     uint32 broadcast_smart_minimum_interval_secs = 11;
   }

--- a/meshtastic/localonly.proto
+++ b/meshtastic/localonly.proto
@@ -112,7 +112,7 @@ message LocalModuleConfig {
   ModuleConfig.NeighborInfoConfig neighbor_info = 11;
 
   /*
-   * The part of the config that is specific to the Neighbor Info module
+   * The part of the config that is specific to the Ambient Lighting module
    */
    ModuleConfig.AmbientLightingConfig ambient_lighting = 12;
 

--- a/meshtastic/localonly.proto
+++ b/meshtastic/localonly.proto
@@ -117,9 +117,9 @@ message LocalModuleConfig {
    ModuleConfig.AmbientLightingConfig ambient_lighting = 12;
 
   /*
-   * The part of the config that is specific to the Neighbor Info module
+   * The part of the config that is specific to the Detection Sensor module
    */
-  ModuleConfig.DetectionConfig detection = 13;
+  ModuleConfig.DetectionSensorConfig detection_sensor = 13;
 
   /*
    * A version integer used to invalidate old save files when we make

--- a/meshtastic/localonly.proto
+++ b/meshtastic/localonly.proto
@@ -112,6 +112,16 @@ message LocalModuleConfig {
   ModuleConfig.NeighborInfoConfig neighbor_info = 11;
 
   /*
+   * The part of the config that is specific to the Neighbor Info module
+   */
+   ModuleConfig.AmbientLightingConfig ambient_lighting = 12;
+
+  /*
+   * The part of the config that is specific to the Neighbor Info module
+   */
+  ModuleConfig.DetectionConfig detection = 13;
+
+  /*
    * A version integer used to invalidate old save files when we make
    * incompatible changes This integer is set at build time and is private to
    * NodeDB.cpp in the device code.

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1094,7 +1094,7 @@ enum CriticalErrorCode {
   TRANSMIT_FAILED = 8;
 
   /*
-   * We detected that the main CPU voltage dropped below the minumum acceptable value
+   * We detected that the main CPU voltage dropped below the minimum acceptable value
    */
   BROWNOUT = 9;
 

--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -23,3 +23,6 @@
 *AmbientLightingConfig.red int_size:8
 *AmbientLightingConfig.green int_size:8
 *AmbientLightingConfig.blue int_size:8
+
+*DetectionConfig.monitor_pin int_size:8
+*DetectionConfig.name max_size:20

--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -24,5 +24,5 @@
 *AmbientLightingConfig.green int_size:8
 *AmbientLightingConfig.blue int_size:8
 
-*DetectionConfig.monitor_pin int_size:8
-*DetectionConfig.name max_size:20
+*DetectionSensorConfig.monitor_pin int_size:8
+*DetectionSensorConfig.name max_size:20

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -128,30 +128,35 @@ message ModuleConfig {
      * Works as a sort of status heartbeat for peace of mind
      */
     uint32 state_broadcast_secs = 3;
-
-    /*
-     * GPIO pin to monitor for state changes
-     */
-    uint32 monitor_pin = 4;
-
-    /*
-     * Whether or not the GPIO pin state detection is triggered on HIGH (1)
-     * Otherwise LOW (0)
-     */
-    bool detection_triggered_high = 5;
-
     /*
      * Send ASCII bell with alert message
      * Useful for triggering ext. notification on bell
      */
-    bool send_bell = 6;
+    bool send_bell = 4;
 
     /*
      * Friendly name used to format message sent to mesh
      * Example: A name "Motion" would result in a message "Motion detected"
      * Maximum length of 20 characters
      */
-    string name = 7;
+    string name = 5;
+
+    /*
+     * GPIO pin to monitor for state changes
+     */
+    uint32 monitor_pin = 6;
+
+    /*
+     * Whether or not the GPIO pin state detection is triggered on HIGH (1)
+     * Otherwise LOW (0)
+     */
+    bool detection_triggered_high = 7;
+
+    /*
+     * Whether or not use INPUT_PULLUP mode for GPIO pin
+     * Only applicable if the board uses pull-up resistors on the pin
+     */
+    bool use_pullup = 8;
   }
 
   /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -120,7 +120,7 @@ message ModuleConfig {
     /*
      * Interval in seconds of how often we can send a message to the mesh when a state change is detected
      */
-    uint32 minumum_update_interval = 2;
+    uint32 minimum_update_interval = 2;
 
     /*
      * GPIO pin to monitor for state changes

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -109,9 +109,9 @@ message ModuleConfig {
   }
 
   /*
-   * Detection Module Config
+   * Detection Sensor Module Config
    */
-   message DetectionConfig {
+   message DetectionSensorConfig {
     /*
      * Whether the Module is enabled
      */
@@ -657,7 +657,7 @@ message ModuleConfig {
     /*
      * TODO: REPLACE
      */
-    DetectionConfig detection = 12;
+    DetectionSensorConfig detection_sensor = 12;
   }
 }
 

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -120,31 +120,38 @@ message ModuleConfig {
     /*
      * Interval in seconds of how often we can send a message to the mesh when a state change is detected
      */
-    uint32 minimum_update_interval = 2;
+    uint32 minimum_broadcast_secs = 2;
+
+    /*
+     * Interval in seconds of how often we should send a message to the mesh with the current state regardless of changes
+     * When set to 0, only state changes will be broadcasted
+     * Works as a sort of status heartbeat for peace of mind
+     */
+    uint32 state_broadcast_secs = 3;
 
     /*
      * GPIO pin to monitor for state changes
      */
-    uint32 monitor_pin = 3;
+    uint32 monitor_pin = 43;
 
     /*
      * Whether or not the GPIO pin state detection is triggered on HIGH (1)
      * Otherwise LOW (0)
      */
-    bool detection_triggered_high = 4;
+    bool detection_triggered_high = 5;
 
     /*
      * Send ASCII bell with alert message
-     * Useful for trigger ext. notification on bell
+     * Useful for triggering ext. notification on bell
      */
-    bool send_bell = 5;
+    bool send_bell = 6;
 
     /*
      * Friendly name used to format message sent to mesh
      * Example: A name "Motion" would result in a message "Motion detected"
      * Maximum length of 20 characters
      */
-    string name = 6;
+    string name = 7;
   }
 
   /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -132,7 +132,7 @@ message ModuleConfig {
     /*
      * GPIO pin to monitor for state changes
      */
-    uint32 monitor_pin = 43;
+    uint32 monitor_pin = 4;
 
     /*
      * Whether or not the GPIO pin state detection is triggered on HIGH (1)

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -118,7 +118,7 @@ message ModuleConfig {
     bool enabled = 1;
 
     /*
-     * Interval in seconds of how often we can send a message, if a state change is detected
+     * Interval in seconds of how often we can send a message to the mesh when a state change is detected
      */
     uint32 minumum_update_interval = 2;
 

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -109,6 +109,45 @@ message ModuleConfig {
   }
 
   /*
+   * Detection Module Config
+   */
+   message DetectionConfig {
+    /*
+     * Whether the Module is enabled
+     */
+    bool enabled = 1;
+
+    /*
+     * Interval in seconds of how often we can send a message, if a state change is detected
+     */
+    uint32 minumum_update_interval = 2;
+
+    /*
+     * GPIO pin to monitor for state changes
+     */
+    uint32 monitor_pin = 3;
+
+    /*
+     * Whether or not the GPIO pin state detection is triggered on HIGH (1)
+     * Otherwise LOW (0)
+     */
+    bool detection_triggered_high = 4;
+
+    /*
+     * Send ASCII bell with alert message
+     * Useful for trigger ext. notification on bell
+     */
+    bool send_bell = 5;
+
+    /*
+     * Friendly name used to format message sent to mesh
+     * Example: A name "Motion" would result in a message "Motion detected"
+     * Maximum length of 20 characters
+     */
+    string name = 6;
+  }
+
+  /*
    * Audio Config for codec2 voice
    */
   message AudioConfig {
@@ -614,9 +653,12 @@ message ModuleConfig {
      * TODO: REPLACE
      */
     AmbientLightingConfig ambient_lighting = 11;
+
+    /*
+     * TODO: REPLACE
+     */
+    DetectionConfig detection = 12;
   }
-
-
 }
 
 /*


### PR DESCRIPTION
I've come to the realization that the remote hardware module is just not user friendly at all, and I don't believe it ever will be. This is my solution for the increasing number of folks wanting a simple way to setup PIR motions sensors, reed switches, rain sensors etc that have simple on/off states. This will allow a user to assign a friendly name and gpio pin to monitor for the state change message. I also think, like most modules we can auto-detect a small curated list of i2c based sensors like RAK's human presence radar sensor for instance and utilize those automatically as well.