### PR TITLE
Generalize E22-900M_S3 to EBYTE_ESP32-S3

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -437,9 +437,9 @@ enum HardwareModel {
   HELTEC_HT62 = 53;
 
   /*
-   * E22-900M series modules with ESP32-S3
+   * Boards with EBYTE SPI LoRa modules and ESP32-S3 MCU
    */
-  E22_900M_S3 = 54;
+  EBYTE_ESP32_S3 = 54;
   
   /*
    * ------------------------------------------------------------------------------------------------------------------------------------------

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -437,7 +437,7 @@ enum HardwareModel {
   HELTEC_HT62 = 53;
 
   /*
-   * Boards with EBYTE SPI LoRa modules and ESP32-S3 MCU
+   * EBYTE SPI LoRa module and ESP32-S3
    */
   EBYTE_ESP32_S3 = 54;
   


### PR DESCRIPTION
For https://github.com/meshtastic/firmware/pull/2882 to encompass more EBYTE modules without requiring adding future variants