### PR TITLE
Ext. Notification use i2s audio interface as buzzer

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -379,6 +379,12 @@ message ModuleConfig {
      * and/or beep for 60 seconds
      */
     uint32 nag_timeout = 14;
+
+    /*
+     * When true, enables devices with native I2S audio output to use the RTTTL over speaker like a buzzer
+     * T-Watch S3 and T-Deck for example have this capability
+     */
+    bool use_i2s_as_buzzer = 15;
   }
 
   /*


### PR DESCRIPTION
For the T-Watch S3, T-Deck, and presumably future Lilygo products with i2s audio interface, we can use the esp8266 audio library to do RTTTL ringtone alerts like we do with a pwm buzzer. We need the ability to turn it off / on though.