### PR TITLE
Flexible configuration for the external notification module

### DIFF
--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -14,6 +14,7 @@
 *ExternalNotificationConfig.output_vibra int_size:8
 *ExternalNotificationConfig.output_buzzer int_size:8
 *ExternalNotificationConfig.nag_timeout int_size:16
+*ExternalNotificationConfig.cases max_count:4
 
 *RemoteHardwareConfig.available_pins max_count:4
 *RemoteHardwarePin.name max_size:15

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package meshtastic;
 
+import "google/protobuf/empty.proto";
+
 option csharp_namespace = "Meshtastic.Protobufs";
 option go_package = "github.com/meshtastic/go/generated";
 option java_outer_classname = "ModuleConfigProtos";
@@ -100,7 +102,7 @@ message ModuleConfig {
      * Whether the Module is enabled
      */
     bool enabled = 1;
-    
+
     /*
      * Interval in seconds of how often we should try to send our
      * Neighbor Info to the mesh
@@ -297,7 +299,10 @@ message ModuleConfig {
   }
 
   /*
-   * External Notifications Config
+   * External Notifications Config.
+   *
+   * The deprecated fields will be converted into a new-style list of
+   * ExternalNotificationCase messages.
    */
   message ExternalNotificationConfig {
     /*
@@ -331,40 +336,106 @@ message ModuleConfig {
     uint32 output_buzzer = 9;
 
     /*
-     * IF this is true, the 'output' Pin will be pulled active high, false
-     * means active low.
+     * If this is true, the primary 'output' Pin will be pulled active high,
+     * false means active low.
      */
     bool active = 4;
 
     /*
      * True: Alert when a text message arrives (output)
+     *
+     * Deprecated: Use this ExternalNotificationCase instead:
+     *
+     *   case {
+     *     condition {
+     *       content_any: true
+     *     }
+     *     actions {
+     *       output_primary: true
+     *     }
+     *   }
      */
-    bool alert_message = 5;
+    bool alert_message = 5 [deprecated = true];
 
     /*
      * True: Alert when a text message arrives (output_vibra)
+     *
+     * Deprecated: Use this ExternalNotificationCase instead:
+     *
+     *   case {
+     *     condition {
+     *       content_any: true
+     *     }
+     *     actions {
+     *       output_vibra: true
+     *     }
+     *   }
      */
-    bool alert_message_vibra = 10;
+    bool alert_message_vibra = 10 [deprecated = true];
 
     /*
      * True: Alert when a text message arrives (output_buzzer)
+     *
+     * Deprecated: Use this ExternalNotificationCase instead:
+     *
+     *   case {
+     *     condition {
+     *       content_any: true
+     *     }
+     *     actions {
+     *       output_buzzer: true
+     *     }
+     *   }
      */
-    bool alert_message_buzzer = 11;
+    bool alert_message_buzzer = 11 [deprecated = true];
 
     /*
      * True: Alert when the bell character is received (output)
+     *
+     * Deprecated: Use this ExternalNotificationCase instead:
+     *
+     *   case {
+     *     condition {
+     *       content_bell: true
+     *     }
+     *     actions {
+     *       output_primary: true
+     *     }
+     *   }
      */
-    bool alert_bell = 6;
+    bool alert_bell = 6 [deprecated = true];
 
     /*
      * True: Alert when the bell character is received (output_vibra)
+     *
+     * Deprecated: Use this ExternalNotificationCase instead:
+     *
+     *   case {
+     *     condition {
+     *       content_bell: true
+     *     }
+     *     actions {
+     *       output_vibra: true
+     *     }
+     *   }
      */
-    bool alert_bell_vibra = 12;
+    bool alert_bell_vibra = 12 [deprecated = true];
 
     /*
      * True: Alert when the bell character is received (output_buzzer)
+     *
+     * Deprecated: Use this ExternalNotificationCase instead:
+     *
+     *   case {
+     *     condition {
+     *       content_bell: true
+     *     }
+     *     actions {
+     *       output_buzzer: true
+     *     }
+     *   }
      */
-    bool alert_bell_buzzer = 13;
+    bool alert_bell_buzzer = 13 [deprecated = true];
 
     /*
      * use a PWM output instead of a simple on/off output. This will ignore
@@ -724,4 +795,134 @@ enum RemoteHardwarePinType {
    * GPIO pin can be written to (high / low)
    */
   DIGITAL_WRITE = 2;
+}
+
+/*
+ * An external notification condition and actions.
+ *
+ * When a message matches the ExternalNotificationCondition, each of the
+ * ExternalNotificationActions is executed.
+ *
+ * A case which turns on the buzzer and vibration when receiving a direct
+ * message containing a bell character looks like this:
+ *
+ *   case {
+ *     condition {
+ *       dest_direct: {}
+ *       content_bell: {}
+ *     }
+ *     actions {
+ *       output_buzzer: {}
+ *     }
+ *     actions {
+ *       output_vibra: {}
+ *     }
+ *   }
+ */
+message ExternalNotificationCase {
+  /*
+   * The condition to compare against an incoming message.
+   */
+  ExternalNotificationCondition condition = 1;
+
+  /*
+   * The actions to perform if condition matches an incoming message.
+   */
+  repeated ExternalNotificationAction actions = 2;
+}
+
+/*
+ * A matcher for incoming messages. If a message matches this condition, then
+ * the ExternalNotificationActions are executed.
+ *
+ * All oneof groups must match for the overall condition to match the incoming
+ * message.
+ *
+ * Empty oneof groups match everything. This means that a completely empty
+ * ExternalNotificationCondition will match all incoming messages.
+ *
+ * For example, if node 456 received the message:
+ *
+ *   from: 123
+ *   to: 456
+ *   decoded {
+ *     portnum: TEXT_MESSAGE_APP
+ *     payload: "direct"
+ *   }
+ *
+ * Then this ExternalNotificationCondition would match:
+ *
+ *   dest_any: {}
+ *   content_any: {}
+ *
+ * As would the condition:
+ *
+ *   dest_direct: {}
+ *   content_any: {}
+ *
+ * However, this ExternalNotificationCondition would not match:
+ *
+ *   dest_direct: {}
+ *   content_bell: {}
+ *
+ * Because the message does not contain a bell character.
+ */
+message ExternalNotificationCondition {
+
+  /*
+   * Matches the destination of the message. dest_any is selected by default.
+   */
+  oneof destination_condition {
+
+    /*
+     * Matches any destination, either a group or direct message. This is the default.
+     */
+    google.protobuf.Empty dest_any = 1;
+
+    /*
+     * Only match direct messages to this node.
+     */
+    google.protobuf.Empty dest_direct = 2;
+  }
+
+  /*
+   * Matches the content of the message. content_any is selected by default.
+   */
+  oneof content_condition {
+    /*
+     * Matches any message content. This is the default.
+     */
+    google.protobuf.Empty content_any = 3;
+
+    /*
+     * Matches if there is a bell character present anywhere in the message.
+     */
+    google.protobuf.Empty content_bell = 4;
+  }
+}
+
+/*
+ * An external notification action to perform when a message matches an
+ * ExternalNotificationCondition.
+ */
+message ExternalNotificationAction {
+  /*
+   * If no field is set, then no action is performed.
+   */
+  oneof action {
+    /*
+     * Turn on the primary GPIO pin.
+     */
+    google.protobuf.Empty output_primary = 1;
+
+    /*
+     * Turn on the secondary vibration GPIO pin.
+     */
+    google.protobuf.Empty output_vibra = 2;
+
+    /*
+     * Turn on the tertiary buzzer GPIO pin.
+     */
+    google.protobuf.Empty output_buzzer = 3;
+  }
 }

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -350,8 +350,8 @@ message ModuleConfig {
      *     condition {
      *       content_any: {}
      *     }
-     *     actions {
-     *       output_primary: {}
+     *     action {
+     *       output_primary: true
      *     }
      *   }
      */
@@ -366,8 +366,8 @@ message ModuleConfig {
      *     condition {
      *       content_any: {}
      *     }
-     *     actions {
-     *       output_vibra: {}
+     *     action {
+     *       output_vibra: true
      *     }
      *   }
      */
@@ -382,8 +382,8 @@ message ModuleConfig {
      *     condition {
      *       content_any: {}
      *     }
-     *     actions {
-     *       output_buzzer: {}
+     *     action {
+     *       output_buzzer: true
      *     }
      *   }
      */
@@ -398,8 +398,8 @@ message ModuleConfig {
      *     condition {
      *       content_bell: {}
      *     }
-     *     actions {
-     *       output_primary: {}
+     *     action {
+     *       output_primary: true
      *     }
      *   }
      */
@@ -414,8 +414,8 @@ message ModuleConfig {
      *     condition {
      *       content_bell: {}
      *     }
-     *     actions {
-     *       output_vibra: {}
+     *     action {
+     *       output_vibra: true
      *     }
      *   }
      */
@@ -430,8 +430,8 @@ message ModuleConfig {
      *     condition {
      *       content_bell: {}
      *     }
-     *     actions {
-     *       output_buzzer: {}
+     *     action {
+     *       output_buzzer: true
      *     }
      *   }
      */
@@ -458,7 +458,7 @@ message ModuleConfig {
     bool use_i2s_as_buzzer = 15;
 
     /*
-     * The conditions and actions for external notifications.
+     * The conditions and action for external notifications.
      *
      * Each case is run independently, so if multiple cases match the same
      * message, then each of their actions are run.
@@ -479,8 +479,8 @@ message ModuleConfig {
      *       dest_direct: {}
      *       content_bell: {}
      *     }
-     *     actions {
-     *       output_primary: {}
+     *     action {
+     *       output_primary: true
      *     }
      *   }
      *
@@ -488,8 +488,8 @@ message ModuleConfig {
      *     condition {
      *       content_any: {}
      *     }
-     *     actions {
-     *       output_vibra: {}
+     *     action {
+     *       output_vibra: true
      *     }
      *   }
      *
@@ -838,10 +838,10 @@ enum RemoteHardwarePinType {
 }
 
 /*
- * An external notification condition and actions.
+ * An external notification condition and action.
  *
- * When a message matches the ExternalNotificationCondition, each of the
- * ExternalNotificationActions is executed.
+ * When a message matches the ExternalNotificationCondition, the
+ * ExternalNotificationAction is executed.
  *
  * A case which turns on the buzzer and vibration when receiving a direct
  * message containing a bell character looks like this:
@@ -851,11 +851,9 @@ enum RemoteHardwarePinType {
  *       dest_direct: {}
  *       content_bell: {}
  *     }
- *     actions {
- *       output_buzzer: {}
- *     }
- *     actions {
- *       output_vibra: {}
+ *     action {
+ *       output_buzzer: true
+ *       output_vibra: true
  *     }
  *   }
  */
@@ -868,12 +866,12 @@ message ExternalNotificationCase {
   /*
    * The actions to perform if condition matches an incoming message.
    */
-  repeated ExternalNotificationAction actions = 2;
+  ExternalNotificationAction action = 2;
 }
 
 /*
  * A matcher for incoming messages. If a message matches this condition, then
- * the ExternalNotificationActions are executed.
+ * the ExternalNotificationAction is executed.
  *
  * All oneof groups must match for the overall condition to match the incoming
  * message.
@@ -942,27 +940,22 @@ message ExternalNotificationCondition {
 }
 
 /*
- * An external notification action to perform when a message matches an
+ * External notification actions to perform when a message matches an
  * ExternalNotificationCondition.
  */
 message ExternalNotificationAction {
   /*
-   * If no field is set, then no action is performed.
+   * Turn on the primary GPIO pin.
    */
-  oneof action {
-    /*
-     * Turn on the primary GPIO pin.
-     */
-    google.protobuf.Empty output_primary = 1;
+  bool output_primary = 1;
 
-    /*
-     * Turn on the secondary vibration GPIO pin.
-     */
-    google.protobuf.Empty output_vibra = 2;
+  /*
+   * Turn on the secondary vibration GPIO pin.
+   */
+  bool output_vibra = 2;
 
-    /*
-     * Turn on the tertiary buzzer GPIO pin.
-     */
-    google.protobuf.Empty output_buzzer = 3;
-  }
+  /*
+   * Turn on the tertiary buzzer GPIO pin.
+   */
+  bool output_buzzer = 3;
 }

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -346,12 +346,12 @@ message ModuleConfig {
      *
      * Deprecated: Use this ExternalNotificationCase instead:
      *
-     *   case {
+     *   cases {
      *     condition {
-     *       content_any: true
+     *       content_any: {}
      *     }
      *     actions {
-     *       output_primary: true
+     *       output_primary: {}
      *     }
      *   }
      */
@@ -362,12 +362,12 @@ message ModuleConfig {
      *
      * Deprecated: Use this ExternalNotificationCase instead:
      *
-     *   case {
+     *   cases {
      *     condition {
-     *       content_any: true
+     *       content_any: {}
      *     }
      *     actions {
-     *       output_vibra: true
+     *       output_vibra: {}
      *     }
      *   }
      */
@@ -378,12 +378,12 @@ message ModuleConfig {
      *
      * Deprecated: Use this ExternalNotificationCase instead:
      *
-     *   case {
+     *   cases {
      *     condition {
-     *       content_any: true
+     *       content_any: {}
      *     }
      *     actions {
-     *       output_buzzer: true
+     *       output_buzzer: {}
      *     }
      *   }
      */
@@ -394,12 +394,12 @@ message ModuleConfig {
      *
      * Deprecated: Use this ExternalNotificationCase instead:
      *
-     *   case {
+     *   cases {
      *     condition {
-     *       content_bell: true
+     *       content_bell: {}
      *     }
      *     actions {
-     *       output_primary: true
+     *       output_primary: {}
      *     }
      *   }
      */
@@ -410,12 +410,12 @@ message ModuleConfig {
      *
      * Deprecated: Use this ExternalNotificationCase instead:
      *
-     *   case {
+     *   cases {
      *     condition {
-     *       content_bell: true
+     *       content_bell: {}
      *     }
      *     actions {
-     *       output_vibra: true
+     *       output_vibra: {}
      *     }
      *   }
      */
@@ -426,12 +426,12 @@ message ModuleConfig {
      *
      * Deprecated: Use this ExternalNotificationCase instead:
      *
-     *   case {
+     *   cases {
      *     condition {
-     *       content_bell: true
+     *       content_bell: {}
      *     }
      *     actions {
-     *       output_buzzer: true
+     *       output_buzzer: {}
      *     }
      *   }
      */
@@ -456,6 +456,46 @@ message ModuleConfig {
      * T-Watch S3 and T-Deck for example have this capability
      */
     bool use_i2s_as_buzzer = 15;
+
+    /*
+     * The conditions and actions for external notifications.
+     *
+     * Each case is run independently, so if multiple cases match the same
+     * message, then each of their actions are run.
+     *
+     * For the example message (where \x07 is the ASCII bell character):
+     *
+     *   from: 123
+     *   to: 456
+     *   decoded {
+     *     portnum: TEXT_MESSAGE_APP
+     *     payload: "direct with bell \x07"
+     *   }
+     *
+     * with the notification config:
+     *
+     *   cases {
+     *     condition {
+     *       dest_direct: {}
+     *       content_bell: {}
+     *     }
+     *     actions {
+     *       output_primary: {}
+     *     }
+     *   }
+     *
+     *   cases {
+     *     condition {
+     *       content_any: {}
+     *     }
+     *     actions {
+     *       output_vibra: {}
+     *     }
+     *   }
+     *
+     * Both the primary output and the vibration pins would be activated.
+     */
+    repeated ExternalNotificationCase cases = 16;
   }
 
   /*
@@ -806,7 +846,7 @@ enum RemoteHardwarePinType {
  * A case which turns on the buzzer and vibration when receiving a direct
  * message containing a bell character looks like this:
  *
- *   case {
+ *   cases {
  *     condition {
  *       dest_direct: {}
  *       content_bell: {}


### PR DESCRIPTION
With multiple different triggers and actions, the number of fields in the `ExternalNotificationConfig` was starting to grow large, and the interactions between the different fields was complicated.

# Example

For example, if someone wanted the configuration

> start the buzzer and vibra when receiving a direct message containing a bell
> character

then the `ExternalNotificationConfig` message would need a field:

```proto
bool alert_bell_direct_message_buzzer = 16;
bool alert_bell_direct_message_vibra = 17;
```

And so on for each combination of conditions and actions.

# This commit

This commit introduces the `ExternalNotificationCase` message, which separates the condition (when to trigger an external notification) from the action (which pin to activate). The previous example would look like this:

```
case {
  condition {
    dest_direct: {}
    content_bell: {}
  }
  actions {
    output_buzzer: {}
  }
  actions {
    output_vibra: {}
  }
}
```

Adding new conditions (such as a message text containing a string prefix or being sent by a particular node) and actions (such as a fourth output pin) does not result in a combinatorial explosion of fields and keeps the implementation simpler.