### PR TITLE
refactor: use repeated fields in `EnvironmentMetrics`

### DIFF
--- a/meshtastic/telemetry.options
+++ b/meshtastic/telemetry.options
@@ -1,4 +1,5 @@
 # options for nanopb
 # https://jpa.kapsi.fi/nanopb/docs/reference.html#proto-file-options
 
-
+*EnvironmentMetrics.weather max_count:8
+*EnvironmentMetrics.power max_count:8

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -40,6 +40,51 @@ message EnvironmentMetrics {
   /*
    * Temperature measured
    */
+  float temperature = 1 [deprecated = true];
+
+  /*
+   * Relative humidity percent measured
+   */
+  float relative_humidity = 2 [deprecated = true];
+
+  /*
+   * Barometric pressure in hPA measured
+   */
+  float barometric_pressure = 3 [deprecated = true];
+
+  /*
+   * Gas resistance in MOhm measured
+   */
+  float gas_resistance = 4 [deprecated = true];
+
+  /*
+   * Voltage measured
+   */
+  float voltage = 5 [deprecated = true];
+
+  /*
+   * Current measured
+   */
+  float current = 6 [deprecated = true];
+
+  /*
+   * WeatherMetric readings
+   */
+  repeated WeatherMetric weather = 7;
+
+  /*
+   * PowerMetric readings
+   */
+  repeated PowerMetric power = 8;
+}
+
+/*
+ * Weather metrics
+ */
+message WeatherMetric {
+  /*
+   * Temperature measured
+   */
   float temperature = 1;
 
   /*
@@ -56,16 +101,21 @@ message EnvironmentMetrics {
    * Gas resistance in MOhm measured
    */
   float gas_resistance = 4;
+}
 
+/*
+ * Power metrics
+ */
+message PowerMetric {
   /*
    * Voltage measured
    */
-  float voltage = 5;
+  float voltage = 1;
 
   /*
    * Current measured
    */
-  float current = 6;
+  float current = 2;
 }
 
 /*


### PR DESCRIPTION
suggestion for handling multiple sensors or sensors with multiple channels from: https://github.com/meshtastic/protobufs/pull/399

opted not to add a separate oneOf since using all fields, including 8 repeated WeatherSensor and PowerSensor each, takes 110 bytes (out of max 237), so there is plenty of room to expand before needing to split into a separate packet.
