### PR TITLE
Changed the variable length of wifi_psk

### DIFF
--- a/meshtastic/config.options
+++ b/meshtastic/config.options
@@ -1,5 +1,5 @@
 *NetworkConfig.wifi_ssid max_size:33
-*NetworkConfig.wifi_psk max_size:64
+*NetworkConfig.wifi_psk max_size:65
 *NetworkConfig.ntp_server max_size:33
 *NetworkConfig.rsyslog_server max_size:33
 


### PR DESCRIPTION

<!-- Describe what you are intending to change -->

# Correct the length of the variable wifi_psk

WiFi PSK can be 256 bits = 32 Bytes and can be represented by a 64 character long hexadecimal string
The size of the variable must be 65 bytes to hold the string and the trailing \0

