### PR TITLE
Add role to NodeInfo/Lite

### DIFF
--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -7,6 +7,7 @@ import "meshtastic/localonly.proto";
 import "meshtastic/mesh.proto";
 import "meshtastic/telemetry.proto";
 import "meshtastic/module_config.proto";
+import "meshtastic/config.proto";
 
 option csharp_namespace = "Meshtastic.Protobufs";
 option go_package = "github.com/meshtastic/go/generated";
@@ -116,7 +117,7 @@ message NodeInfoLite {
    * local channel index we heard that node on. Only populated if its not the default channel.
    */
   uint32 channel = 7;
-  
+
   /*
    * Indicates that the device's role in the mesh
    */

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -116,6 +116,11 @@ message NodeInfoLite {
    * local channel index we heard that node on. Only populated if its not the default channel.
    */
   uint32 channel = 7;
+  
+  /*
+   * Indicates that the device's role in the mesh
+   */
+  Config.DeviceConfig.Role role = 8;
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1046,6 +1046,11 @@ message NodeInfo {
    * local channel index we heard that node on. Only populated if its not the default channel.
    */
   uint32 channel = 7;
+
+  /*
+   * Indicates that the device's role in the mesh
+   */
+  Config.DeviceConfig.Role role = 8;
 }
 
 /*


### PR DESCRIPTION
Closes #404 
This will allow us to know (and store) what each Node's role on the mesh is. I believe it could be helpful information for determining topology along with Neighbors module.