### PR TITLE
update mesh.proto to add CircuitMess Chatter 2

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -455,6 +455,13 @@ enum HardwareModel {
    * Waveshare ESP32-S3-PICO with PICO LoRa HAT and 2.9inch e-Ink
    */
   ESP32_S3_PICO = 55;
+
+  /*
+   * CircuitMess Chatter 2 LLCC68 Lora Module and ESP32 Wroom
+   * Lora module can be swapped out for a Heltec RA-62 which is "almost" pin compatible
+   * with one cut and one jumper Meshtastic works
+  */
+  CHATTER_2 = 56;
   
   /*
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR is the start of adding the Chatter 2 board to Meshtastic

# What does this PR do?
this is a continuation of the Issue:
 [Board]: reconsideration of the chatter 2.0 #2896 

I have debugged the code needed to add this to Meshtastic and am trying to follow the procedure to add a new board.
So this adds the definition in mesh.proto as the first step.