### PR TITLE
Add `via_mqtt` tag to MeshPacket and `ignore_mqtt` to LoRa config

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -866,6 +866,11 @@ message Config {
      * in ignore_incoming will have packets they send dropped on receive (by router.cpp)
      */
     repeated uint32 ignore_incoming = 103;
+
+    /*
+     * If true, the device will not process any packets received via LoRa that passed via MQTT anywhere on the path towards it.
+     */
+    bool ignore_mqtt = 104;
   }
 
   message BluetoothConfig {

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -965,6 +965,11 @@ message MeshPacket {
    * Describe if this message is delayed
    */
   Delayed delayed = 13 [deprecated = true];
+
+  /*
+   * Describes whether this packet passed via MQTT somewhere along the path it currently took.
+   */
+  bool via_mqtt = 14;
 }
 
 /*


### PR DESCRIPTION
This adds a `via_mqtt` tag to the MeshPacket, which indicates whether a packet has passed via MQTT anywhere on the path towards a node. Furthermore, it adds a `ignore_mqtt` option to the LoRa config, to allow users to ignore packets that came via MQTT somewhere. I specifically chose the LoRa config, because it is to ensure packets only arrive via LoRa.

The `via_mqtt` tag can also be used to show on a Traceroute that it didn’t go purely via LoRa if you don’t want to ignore MQTT.

See https://github.com/meshtastic/firmware/pull/3117.