### PR TITLE
Added LilyGo T3 V1.6.1 TCXO board

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -464,6 +464,10 @@ enum HardwareModel {
   CHATTER_2 = 56;
   
   /*
+   * LilyGo T3 V1.6.1 TCXO Version
+   */
+  TLORA_V1_6_1_TCXO;
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The LilyGo T3 V1.6.1 TCXO version is different from the normal version and the original variant cannot be used.
https://www.lilygo.cc/products/lora3?variant=43365007425717