### PR TITLE
Add Singapore Region

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -735,6 +735,11 @@ message Config {
        * Malaysia 919mhz
        */
       MY_919 = 17;
+
+      /*
+       * Singapore 923mhz
+       */
+      SG_923 = 18;
     }
 
     /*


### PR DESCRIPTION
# What does this PR do?

Add 923MHz band for Singapore.

Regulatory reference: https://www.imda.gov.sg/-/media/imda/files/regulation-licensing-and-consultations/ict-standards/telecommunication-standards/radio-comms/imdatssrd.pdf band 30d.

> [Related Issue](https://github.com/meshtastic/firmware/issues/3159)

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
