### PR TITLE
Add device callsign

### DIFF
--- a/meshtastic/atak.options
+++ b/meshtastic/atak.options
@@ -1,4 +1,5 @@
 *Contact.callsign max_size:120
+*Contact.device_callsign max_size:120
 *Status.battery int_size:8
 *PLI.course int_size:16
 *GeoChat.message max_size:200

--- a/meshtastic/atak.proto
+++ b/meshtastic/atak.proto
@@ -198,6 +198,11 @@ message Contact {
    * Callsign
    */
   string callsign = 1;
+
+  /*
+   * Device callsign
+   */
+  string device_callsign = 2;
   /*
    * IP address of endpoint in integer form (0.0.0.0 default)
    */


### PR DESCRIPTION
Ended up needing another property on the message for proper routing within ATAK