### PR TITLE
StoreForward: replace "empty" by "text" and improve comments

### DIFF
--- a/meshtastic/storeforward.options
+++ b/meshtastic/storeforward.options
@@ -1,0 +1,1 @@
+*StoreAndForward.text max_size:237

--- a/meshtastic/storeforward.proto
+++ b/meshtastic/storeforward.proto
@@ -130,12 +130,12 @@ message StoreAndForward {
     bool heartbeat = 7;
 
     /*
-     * Is the heartbeat enabled on the server?
+     * Maximum number of messages the server will return.
      */
     uint32 return_max = 8;
 
     /*
-     * Is the heartbeat enabled on the server?
+     * Maximum history window in minutes the server will return messages from.
      */
     uint32 return_window = 9;
   }
@@ -155,7 +155,8 @@ message StoreAndForward {
     uint32 window = 2;
 
     /*
-     * The window of messages that was used to filter the history client requested
+     * Index in the packet history of the last message sent in a previous request to the server.
+     * Will be sent to the client before sending the history and can be set in a subsequent request to avoid getting packets the server already sent to the client.
      */
     uint32 last_request = 3;
   }
@@ -165,7 +166,7 @@ message StoreAndForward {
    */
   message Heartbeat {
     /*
-     * Number of that will be sent to the client
+     * Period in seconds that the heartbeat is sent out that will be sent to the client
      */
     uint32 period = 1;
 
@@ -200,8 +201,8 @@ message StoreAndForward {
     Heartbeat heartbeat = 4;
 
     /*
-     * Empty Payload
+     * Text from history message.
      */
-    bool empty = 5;
+    bytes text = 5;
   }
 }


### PR DESCRIPTION
This will replace the currently unused "empty" variant of the StoreForward message to "text", such that clients know how to handle the history from the server. Technically a breaking change, but the "empty" variant was not used in the firmware. 

Also updated some of the comments of other fields.