### PR TITLE
Add length to GeoChat.to

### DIFF
--- a/meshtastic/atak.options
+++ b/meshtastic/atak.options
@@ -3,3 +3,4 @@
 *Status.battery int_size:8
 *PLI.course int_size:16
 *GeoChat.message max_size:200
+*GeoChat.to max_size:120


### PR DESCRIPTION
Firmware doesn't like non-fixed size strings for what we're doing with the ATAK plugin