### PR TITLE
StoreForward: add `TEXT_DIRECT` and `TEXT_BROADCAST` RequestResponse tags

### DIFF
--- a/meshtastic/storeforward.proto
+++ b/meshtastic/storeforward.proto
@@ -59,6 +59,16 @@ message StoreAndForward {
     ROUTER_STATS = 7;
 
     /*
+     * Router sends a text message from its history that was a direct message.
+     */
+    ROUTER_TEXT_DIRECT = 8;
+
+    /*
+     * Router sends a text message from its history that was a broadcast.
+     */
+    ROUTER_TEXT_BROADCAST = 9;
+
+    /*
      * Client is an in error state.
      */
     CLIENT_ERROR = 64;


### PR DESCRIPTION
When the S&F router is sending history, the `to` will always be set to the client requesting it, even if it was a broadcast message. With these tags, a client knows whether the original message was actually a direct message or a broadcast.
