### PR TITLE
Add TAK_TRACKER role

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -64,7 +64,7 @@ message Config {
       SENSOR = 6;
 
       /*
-       * Description: Optimized for ATAK system communication, reduces routine broadcasts.
+       * Description: Optimized for ATAK system communication and reduces routine broadcasts.
        * Technical Details: Used for nodes dedicated for connection to an ATAK EUD.
        *    Turns off many of the routine broadcasts to favor CoT packet stream
        *    from the Meshtastic ATAK plugin -> IMeshService -> Node
@@ -87,6 +87,14 @@ message Config {
        *    "I'm lost! Position: lat / long"
        */
       LOST_AND_FOUND = 9;
+      
+      /*
+       * Description: Enables automatic TAK PLI broadcasts and reduces routine broadcasts.
+       * Technical Details: Turns off many of the routine broadcasts to favor ATAK CoT packet stream
+       *    and automatic TAK PLI (position location information) broadcasts.
+       *    Uses position module configuration to determine TAK PLI broadcast interval.
+       */
+      TAK_TRACKER = 10;
     }
 
     /*


### PR DESCRIPTION
This role is for standalone tracker Meshtastic devices (no phone/EUD) in a TAK system.