### PR TITLE
Fix MeshPacket.to comment

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -901,8 +901,7 @@ message MeshPacket {
   fixed32 from = 1;
 
   /*
-   * The (immediate) destination for this packet. If we are using routing, the
-   * final destination will be in payload.dest
+   * The (immediate) destination for this packet
    */
   fixed32 to = 2;
 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -901,8 +901,8 @@ message MeshPacket {
   fixed32 from = 1;
 
   /*
-   * The (immediatSee Priority description for more details.y should be fixed32 instead, this encoding only
-   * hurts the ble link though.
+   * The (immediate) destination for this packet. If we are using routing, the
+   * final destination will be in payload.dest
    */
   fixed32 to = 2;
 


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?

Reverts the comment to it became garbled in https://github.com/meshtastic/protobufs/commit/0221e83d689f7930ed3e5c474eff4fbb8697efbb.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
