### PR TITLE
Remove fixed FIXME in mesh.proto

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -896,7 +896,6 @@ message MeshPacket {
    * The sending node number.
    * Note: Our crypto implementation uses this field as well.
    * See [crypto](/docs/overview/encryption) for details.
-   * FIXME - really should be fixed32 instead, this encoding only hurts the ble link though.
    */
   fixed32 from = 1;
 
@@ -947,8 +946,6 @@ message MeshPacket {
    * any ACK or the completion of a mesh broadcast flood).
    * Note: Our crypto implementation uses this id as well.
    * See [crypto](/docs/overview/encryption) for details.
-   * FIXME - really should be fixed32 instead, this encoding only
-   * hurts the ble link though.
    */
   fixed32 id = 6;
 


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?

Update the comments - looks like these FIXMEs got fixed. The fields are declared as `fixed32` now.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
