### PR TITLE
Station G2

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -350,6 +350,11 @@ enum HardwareModel {
   RP2040_LORA = 30;
 
   /*
+   * B&Q Consulting Station G2: https://wiki.uniteng.com/en/meshtastic/station-g2
+   */
+  STATION_G2 = 31;
+
+  /*
    * ---------------------------------------------------------------------------
    * Less common/prototype boards listed here (needs one more byte over the air)
    * ---------------------------------------------------------------------------


### PR DESCRIPTION
<html><body>
<!--StartFragment--><h3 dir="auto">Description</h3>

<p dir="auto">Meshtastic
 Mesh Device Station G2 is an upgraded design of Station G1, using the 
latest ESP32 S3 MCU. As an RF research project, Station G2 also brings 
key updates in RF. The primary RF design goal of Station G2 is to 
improve the Lora receiving sensitivity by about 4dB based on <a href="https://wiki.uniteng.com/en/meshtastic/station-g2#ultra-low-noise-figure-lna-for-lora" rel="nofollow">a dedicated Ultra-Low Noise Figure LNA</a>. And to increase the transmit power and improve Signal to Noise ratio of short data packets by designing the <a href="https://wiki.uniteng.com/en/meshtastic/station-g2#fast-transient-dc-dc-for-lora-power-amplifier" rel="nofollow">Fast-Transient DC-DC for 35dBm Lora PA</a>.</p> <p dir="auto">For Lora Power Amplifier, <a href="https://wiki.uniteng.com/en/meshtastic/station-g2#lora-power-amplifier" rel="nofollow">the
 1 dB Compression Point (P1dB) is 35 dBm (3.16 W), and the maximum RF 
output power is 36.5 dBm (4.46 W) for US915 and 37 dBm (5 W) for EU868.</a></p> <p dir="auto">Station
 G2 has a rugged SMA antenna socket and rich external IO interfaces. It 
can be powered by either 15VDC USB Type C PD protocol or <a href="https://wiki.uniteng.com/en/meshtastic/station-g2#external-power-supply" rel="nofollow">9VDC-19VDC External Power Supply</a>. These features make Station G2 ideally suited as a Fixed-Location Base Station or Vehicle-Mounted Base Station.</p> <h4 id="user-content-features-comparison-of-station-g2-and-station-g1" dir="auto"> Features Comparison of Station G2 and Station G1</h4> 

Editions | Station G2 | Station G1
-- | -- | --
Core Research Areas | Ultra-Low Noise Figure LNA for LoRaFast-Transient DC-DC for LoRa PA | Modern Cost-Effective RF Power Amplifier RF Components/Materials Measurement and Modeling
Product Status | ACTIVE | OBSOLETE
Current Hardware Version | 18 Jan 2024 | 20 Sep 2022
Initial Release Date | 18 Jan 2024 | 12 Jun 2022
Lora RF Max Output Power | Up to 35 dBm (P1dB Point) | Up to 35 dBm (Maximum RF Output Power)
Frequency Reference for Lora | 32MHz TCXO (+-1.5 ppm) | 32MHz XTAL (+-10 ppm)
Lora Ultra-Low Noise Figure LNA | Typical Gain: 18.5 dB, Typical Noise Figure: 1.8 dB | -
Fast-Transient DC-DC for LoRa PA | Transient Response Time < 18us, Maximum Transient Voltage  Deviation < 275mV, Phase Margin > 66.73 Degrees, Ripple < 30mV,  Test Condition: 0A-3A@7.5VDC Dynamic Test, Input Voltage 15VDC | -
LoRa Transceiver | SX1262 | SX1262
Lora Operation Frequency | US915MHz / EU868MHz | US915MHz / EU868MHz
MCU | ESP32 S3 (Flash: 16MB, PSRAM: 8MB) | ESP32 (Flash: 4MB, PSRAM: -)
WIFI | YES | YES
Bluetooth | v5.0 | v4.2
Satellite Navigation | Optional (1x GROVE GPS Socket) | Optional
USB Connector | Type C (PD Protocol) | Type C (PD Protocol)
Screen | 1.3 Inch OLED Screen | 1.3 Inch OLED Screen
Battery | - | Optional 12V Battery Docker
Power Input Socket | 15VDC USB Type C PD protocol, 1x5P Pitch=1.5mm Socket (9VDC-19VDC External Power Supply) | USB Type C, 1x2P Pitch=2.5mm Socket
LoRa Antenna | SMA Socket | SMA Socket
Accessories | 1x GROVE GPS Socket, 1x GROVE I2C Socket, 1x SparkFun QWIIC I2C Socket and 1x IO Extension Socket | 1x IO Extension Socket
Typical Scenarios | Fixed-Location Base Stations and Vehicle-Mounted Base Stations | Fixed-Location Base Stations and Vehicle-Mounted Base Stations

