### PR TITLE
Add hopStart to MeshPacket

### DIFF
--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -26,6 +26,7 @@
 *MeshPacket.encrypted max_size:256
 *MeshPacket.payload_variant anonymous_oneof:true
 *MeshPacket.hop_limit int_size:8
+*MeshPacket.hop_start int_size:8
 *MeshPacket.channel int_size:8
 
 *QueueStatus.res int_size:8

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1003,6 +1003,12 @@ message MeshPacket {
    * Describes whether this packet passed via MQTT somewhere along the path it currently took.
    */
   bool via_mqtt = 14;
+
+  /* 
+   * Hop limit with which the original packet started. Sent via LoRa using three bits in the unencrypted header. 
+   * When receiving a packet, the difference between hop_start and hop_limit gives how many hops it traveled.
+   */ 
+  uint32 hop_start = 15;
 }
 
 /*
@@ -1540,4 +1546,3 @@ message DeviceMetadata {
    */
   bool hasRemoteHardware = 10;
 }
-


### PR DESCRIPTION
In order to implement RFC https://github.com/meshtastic/rfcs/pull/8 and corresponding firmware issue https://github.com/meshtastic/firmware/issues/3239. 

With this clients can use the following pseudocode when receiving a packet to display routing information:
```
if (hopStart != 0 && (hopStart-hopLimit !=0)):
	displayHopsAway(hopStart-hopLimit) 
else: 
	displayRSSIandSNR()
```

Note that unlike SNR, the amount of hops is not (yet) in the NodeInfo, but can be updated for each received packet.