### PR TITLE
Add via_mqtt and hops_away to NodeInfo/Lite

### DIFF
--- a/meshtastic/deviceonly.options
+++ b/meshtastic/deviceonly.options
@@ -16,3 +16,4 @@
 *DeviceState.node_remote_hardware_pins max_count:12
 
 *NodeInfoLite.channel int_size:8
+*NodeInfoLite.hops_away int_size:8

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -116,6 +116,16 @@ message NodeInfoLite {
    * local channel index we heard that node on. Only populated if its not the default channel.
    */
   uint32 channel = 7;
+
+  /*
+   * True if we witnessed the node over MQTT instead of LoRA transport
+   */
+  bool via_mqtt = 8;
+
+  /*
+   * Number of hops away from us this node is (0 if adjacent)
+   */
+  uint32 hops_away = 9;
 }
 
 /*

--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -14,6 +14,7 @@
 *Data.payload max_size:237
 
 *NodeInfo.channel int_size:8
+*NodeInfo.hops_away int_size:8
 
 # Big enough for 1.2.28.568032c-d
 *MyNodeInfo.firmware_version max_size:18

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1116,6 +1116,16 @@ message NodeInfo {
    * local channel index we heard that node on. Only populated if its not the default channel.
    */
   uint32 channel = 7;
+
+  /*
+   * True if we witnessed the node over MQTT instead of LoRA transport
+   */
+  bool via_mqtt = 8;
+
+  /*
+   * Number of hops away from us this node is (0 if adjacent)
+   */
+  uint32 hops_away = 9;
 }
 
 /*


### PR DESCRIPTION
The intent of these changes is to reveal some insights to the user about how the delivery is happening over the mesh per node. 
Clients should be able to inform users if a node was seen over the internet via MQTT, if it's a direct neighbor, or witnessed over one of more hops from other nodes in the mesh. 