### PR TITLE
Remove Broken Links to Documentation

### DIFF
--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -48,28 +48,28 @@ enum PortNum {
 
   /*
    * The built-in position messaging app.
-   * Payload is a [Position](/docs/developers/protobufs/api#position) message
+   * Payload is a Position message.
    * ENCODING: Protobuf
    */
   POSITION_APP = 3;
 
   /*
    * The built-in user info app.
-   * Payload is a [User](/docs/developers/protobufs/api#user) message
+   * Payload is a User message.
    * ENCODING: Protobuf
    */
   NODEINFO_APP = 4;
 
   /*
    * Protocol control packets for mesh protocol use.
-   * Payload is a [Routing](/docs/developers/protobufs/api#routing) message
+   * Payload is a Routing message.
    * ENCODING: Protobuf
    */
   ROUTING_APP = 5;
 
   /*
    * Admin control packets.
-   * Payload is a [AdminMessage](/docs/developers/protobufs/api#adminmessage) message
+   * Payload is a AdminMessage message.
    * ENCODING: Protobuf
    */
   ADMIN_APP = 6;
@@ -85,7 +85,7 @@ enum PortNum {
 
   /*
    * Waypoint payloads.
-   * Payload is a [Waypoint](/docs/developers/protobufs/api#waypoint) message
+   * Payload is a Waypoint message.
    * ENCODING: Protobuf
    */
   WAYPOINT_APP = 8;


### PR DESCRIPTION
This PR removes links to pages in the documentation that no longer exist.