### PR TITLE
add BMP085 (BMP180) sensor to enum TelemetrySensorType

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -279,6 +279,9 @@ enum TelemetrySensorType {
    */
   INA3221 = 14;
 
-
+  /*
+   * BMP085/BMP180 High accuracy temperature and pressure (older Version of BMP280)
+   */
+  BMP085 = 15;
 
 }


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

add a new value (15) for BMP085 in TelemetrySensorType as prerequisite to implement environment sensor BMP085/BMP180

<!-- Please remove or replace the issue url -->

[Related Issue](https://github.com/meshtastic/protobufs/issues/458)
