### PR TITLE
MapReport message and config for MQTT

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -70,6 +70,31 @@ message ModuleConfig {
      * If true, we can use the connected phone / client to proxy messages to MQTT instead of a direct connection
      */
     bool proxy_to_client_enabled = 9;
+
+    /*
+     * If true, we will periodically report unencrypted information about our node to a map via MQTT
+     */
+    bool map_reporting_enabled = 10;
+
+    /*
+     * Settings for reporting information about our node to a map via MQTT
+     */
+    MapReportSettings map_report_settings = 11;
+  }
+
+  /*
+   * Settings for reporting unencrypted information about our node to a map via MQTT
+   */
+  message MapReportSettings {
+    /*
+     * How often we should report our info to the map (in seconds)
+     */
+    uint32 publish_interval_secs = 1;
+
+    /*
+     * Bits of precision for the location sent (default of 32 is full precision).
+     */
+    uint32 position_precision = 2;
   }
 
   /*

--- a/meshtastic/mqtt.options
+++ b/meshtastic/mqtt.options
@@ -4,4 +4,5 @@
 
 *MapReport.long_name max_size:40
 *MapReport.short_name max_size:5
+*MapReport.firmware_version max_size:18
 *MapReport.num_online_local_nodes int_size:16

--- a/meshtastic/mqtt.options
+++ b/meshtastic/mqtt.options
@@ -1,3 +1,7 @@
 *ServiceEnvelope.packet type:FT_POINTER
 *ServiceEnvelope.channel_id type:FT_POINTER
 *ServiceEnvelope.gateway_id type:FT_POINTER
+
+*MapReport.long_name max_size:40
+*MapReport.short_name max_size:5
+*MapReport.num_online_local_nodes int_size:16

--- a/meshtastic/mqtt.proto
+++ b/meshtastic/mqtt.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package meshtastic;
 
 import "meshtastic/mesh.proto";
+import "meshtastic/config.proto";
 
 option csharp_namespace = "Meshtastic.Protobufs";
 option go_package = "github.com/meshtastic/go/generated";
@@ -30,4 +31,71 @@ message ServiceEnvelope {
    * the globally trusted nodenum
    */
   string gateway_id = 3;
+}
+
+/*
+ * Information about a node intended to be reported unencrypted to a map using MQTT.
+ */
+message MapReport {
+  /*
+   * A full name for this user, i.e. "Kevin Hester"
+   */
+  string long_name = 1;
+
+  /*
+   * A VERY short name, ideally two characters.
+   * Suitable for a tiny OLED screen
+   */
+  string short_name = 2;
+
+  /*
+  * Role of the node that applies specific settings for a particular use-case
+  */
+  Config.DeviceConfig.Role role = 3;
+
+  /*
+   * Hardware model of the node, i.e. T-Beam, Heltec V3, etc...
+   */
+  HardwareModel hw_model = 4;
+
+  /*
+  * The region code for the radio (US, CN, EU433, etc...)
+  */
+  Config.LoRaConfig.RegionCode region = 5;
+
+  /*
+  * Modem preset used by the radio (LongFast, MediumSlow, etc...)
+  */
+  Config.LoRaConfig.ModemPreset modem_preset = 6;
+
+  /*
+  * Whether the node has a channel with default PSK and name (LongFast, MediumSlow, etc...)
+  * and it uses the default frequency slot given the region and modem preset.
+  */
+  bool has_default_channel = 7;
+
+  /*
+   * Latitude: multiply by 1e-7 to get degrees in floating point
+   */
+  sfixed32 latitude_i = 8;
+
+  /*
+   * Longitude: multiply by 1e-7 to get degrees in floating point
+   */
+  sfixed32 longitude_i = 9;
+
+  /*
+   * Altitude in meters above MSL
+   */
+  int32 altitude = 10;
+
+  /*
+   * Indicates the bits of precision for latitude and longitude set by the sending node
+   */
+  uint32 position_precision = 11;
+
+  /*
+   * Number of online nodes (heard in the last 2 hours) this node has in its list that were received locally (not via MQTT)
+   */
+  uint32 num_online_local_nodes = 12;
 }

--- a/meshtastic/mqtt.proto
+++ b/meshtastic/mqtt.proto
@@ -59,43 +59,48 @@ message MapReport {
   HardwareModel hw_model = 4;
 
   /*
+   * Device firmware version string
+   */
+  string firmware_version = 5;
+
+  /*
   * The region code for the radio (US, CN, EU433, etc...)
   */
-  Config.LoRaConfig.RegionCode region = 5;
+  Config.LoRaConfig.RegionCode region = 6;
 
   /*
   * Modem preset used by the radio (LongFast, MediumSlow, etc...)
   */
-  Config.LoRaConfig.ModemPreset modem_preset = 6;
+  Config.LoRaConfig.ModemPreset modem_preset = 7;
 
   /*
   * Whether the node has a channel with default PSK and name (LongFast, MediumSlow, etc...)
   * and it uses the default frequency slot given the region and modem preset.
   */
-  bool has_default_channel = 7;
+  bool has_default_channel = 8;
 
   /*
    * Latitude: multiply by 1e-7 to get degrees in floating point
    */
-  sfixed32 latitude_i = 8;
+  sfixed32 latitude_i = 9;
 
   /*
    * Longitude: multiply by 1e-7 to get degrees in floating point
    */
-  sfixed32 longitude_i = 9;
+  sfixed32 longitude_i = 10;
 
   /*
    * Altitude in meters above MSL
    */
-  int32 altitude = 10;
+  int32 altitude = 11;
 
   /*
    * Indicates the bits of precision for latitude and longitude set by the sending node
    */
-  uint32 position_precision = 11;
+  uint32 position_precision = 12;
 
   /*
    * Number of online nodes (heard in the last 2 hours) this node has in its list that were received locally (not via MQTT)
    */
-  uint32 num_online_local_nodes = 12;
+  uint32 num_online_local_nodes = 13;
 }

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -192,6 +192,11 @@ enum PortNum {
   ATAK_PLUGIN = 72;
 
   /*
+   * Provides unencrypted information about a node for consumption by a map via MQTT
+   */
+  MAP_REPORT_APP = 73;
+
+  /*
    * Private applications should use portnums >= 256.
    * To simplify initial development and testing you can use "PRIVATE_APP"
    * in your code without needing to rebuild protobuf files (via [regen-protos.sh](https://github.com/meshtastic/firmware/blob/master/bin/regen-protos.sh))


### PR DESCRIPTION
This adds a special `MapReport` message and corresponding settings in the MQTT module config. Related feature request is https://github.com/meshtastic/firmware/issues/3336.
Essentially it makes it easy to periodically report some information about a node (like long/short name, position, region, modem preset) for consumption by a map via MQTT only, such that you don't need to enable uplink on your primary channel.
