### PR TITLE
Add explicit Heartbeat packet for clients to keep alive (serial) connections

### DIFF
--- a/meshtastic/clientonly.proto
+++ b/meshtastic/clientonly.proto
@@ -40,3 +40,11 @@ message DeviceProfile {
    */
   optional LocalModuleConfig module_config = 5;
 }
+
+/* 
+ * A heartbeat message is sent by a node to indicate that it is still alive.
+ * This is currently only needed to keep serial connections alive.
+ */
+message Heartbeat {
+  
+}


### PR DESCRIPTION
# What does this PR do?

This PR adds an explicit `Heartbeat` message that clients will send to devices to signal that the client is still connected. Currently this is only needed for serial connections, although it is recommended to do this for all connections as this packet will not be sent over the mesh.

While the device will not time out if it hears any packet from the client, adding an explicit message is intended to serve as a reminder to client developers to send keep-alive packets explicitly.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
