### PR TITLE
Add is_favorite to NodeInfo/Lite

### DIFF
--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -130,7 +130,7 @@ message NodeInfoLite {
 
   /*
    * True if node is in our favorites list
-   * Persists between NodeDB resets and internal clean up
+   * Persists between NodeDB internal clean ups
    */
   bool is_favorite = 10;
 }

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -127,6 +127,12 @@ message NodeInfoLite {
    * Number of hops away from us this node is (0 if adjacent)
    */
   uint32 hops_away = 9;
+
+  /*
+   * True if node is in our favorites list
+   * Persists between NodeDB resets and internal clean up
+   */
+  bool is_favorite = 10;
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1129,7 +1129,7 @@ message NodeInfo {
   
   /*
    * True if node is in our favorites list
-   * Persists between NodeDB resets and internal clean up
+   * Persists between NodeDB internal clean ups
    */
   bool is_favorite = 10;
 }

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1126,6 +1126,12 @@ message NodeInfo {
    * Number of hops away from us this node is (0 if adjacent)
    */
   uint32 hops_away = 9;
+  
+  /*
+   * True if node is in our favorites list
+   * Persists between NodeDB resets and internal clean up
+   */
+  bool is_favorite = 10;
 }
 
 /*


### PR DESCRIPTION
Favorites will be at the top of the list for client node lists and survive NodeDB cleanups.

Closes #429 