### PR TITLE
Move remote hardware pins to sever problematic device_only dependency

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -5,9 +5,9 @@ package meshtastic;
 import "meshtastic/channel.proto";
 import "meshtastic/config.proto";
 import "meshtastic/connection_status.proto";
-import "meshtastic/deviceonly.proto";
 import "meshtastic/mesh.proto";
 import "meshtastic/module_config.proto";
+import "meshtastic/remote_hardware.proto";
 
 option csharp_namespace = "Meshtastic.Protobufs";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -7,7 +7,6 @@ import "meshtastic/config.proto";
 import "meshtastic/connection_status.proto";
 import "meshtastic/mesh.proto";
 import "meshtastic/module_config.proto";
-import "meshtastic/remote_hardware.proto";
 
 option csharp_namespace = "Meshtastic.Protobufs";
 option go_package = "github.com/meshtastic/go/generated";

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -7,6 +7,7 @@ import "meshtastic/localonly.proto";
 import "meshtastic/mesh.proto";
 import "meshtastic/telemetry.proto";
 import "meshtastic/module_config.proto";
+import "meshtastic/remote_hardware.proto";
 import "nanopb.proto";
 
 option csharp_namespace = "Meshtastic.Protobufs";
@@ -253,19 +254,4 @@ message OEMStore {
    * A Preset LocalModuleConfig to apply during factory reset
    */
   LocalModuleConfig oem_local_module_config = 8;
-}
-
-/*
- * RemoteHardwarePins associated with a node
- */
-message NodeRemoteHardwarePin {
-  /*
-   * The node_num exposing the available gpio pin
-   */
-  uint32 node_num = 1;
-
-  /*
-   * The the available gpio pin for usage with RemoteHardware module
-   */
-  RemoteHardwarePin pin = 2;
 }

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -7,7 +7,6 @@ import "meshtastic/localonly.proto";
 import "meshtastic/mesh.proto";
 import "meshtastic/telemetry.proto";
 import "meshtastic/module_config.proto";
-import "meshtastic/remote_hardware.proto";
 import "nanopb.proto";
 
 option csharp_namespace = "Meshtastic.Protobufs";

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1581,3 +1581,18 @@ message DeviceMetadata {
 message Heartbeat {
   
 }
+
+/*
+ * RemoteHardwarePins associated with a node
+ */
+message NodeRemoteHardwarePin {
+  /*
+   * The node_num exposing the available gpio pin
+   */
+  uint32 node_num = 1;
+
+  /*
+   * The the available gpio pin for usage with RemoteHardware module
+   */
+  RemoteHardwarePin pin = 2;
+}

--- a/meshtastic/remote_hardware.proto
+++ b/meshtastic/remote_hardware.proto
@@ -73,3 +73,18 @@ message HardwareMessage {
    */
   uint64 gpio_value = 3;
 }
+
+/*
+ * RemoteHardwarePins associated with a node
+ */
+message NodeRemoteHardwarePin {
+  /*
+   * The node_num exposing the available gpio pin
+   */
+  uint32 node_num = 1;
+
+  /*
+   * The the available gpio pin for usage with RemoteHardware module
+   */
+  RemoteHardwarePin pin = 2;
+}

--- a/meshtastic/remote_hardware.proto
+++ b/meshtastic/remote_hardware.proto
@@ -73,18 +73,3 @@ message HardwareMessage {
    */
   uint64 gpio_value = 3;
 }
-
-/*
- * RemoteHardwarePins associated with a node
- */
-message NodeRemoteHardwarePin {
-  /*
-   * The node_num exposing the available gpio pin
-   */
-  uint32 node_num = 1;
-
-  /*
-   * The the available gpio pin for usage with RemoteHardware module
-   */
-  RemoteHardwarePin pin = 2;
-}


### PR DESCRIPTION
We need to move this one, because drawing a dependency on deviceonly.proto is no bueno.