### PR TITLE
Add E-Ink options to DisplayConfig

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -645,6 +645,44 @@ message Config {
      * Should we wake the screen up on accelerometer detected motion or tap
      */
     bool wake_on_tap_or_motion = 10;
+
+    enum EInkScreensaver {
+      /*
+       * Description: Label overtop existing screen image
+       */
+      OVERLAY = 0;
+
+      /*
+       * Description: Meshtastic logo
+       */
+      LOGO = 1;
+
+      /*
+       * Description: Clear screen
+       */
+      BLANK = 2;
+
+      /*
+       * Description: No change from existing screen image
+       */
+      NONE = 3;
+
+      /*
+       * Description: A variant-specific custom screensaver, if one exists
+       */
+      CUSTOM = 4;
+    }
+
+    /*
+     * Description: Which behavior E-Ink display uses when updates are paused
+     */
+    EInkScreensaver eink_screensaver = 11;
+
+    /*
+     * Descrption: Will perform slower, more robust refreshes, improving outdoor performance for some displays
+     * Technical Details: Indicates a preference for full-refresh
+     */
+    bool eink_direct_sun = 12;
   }
 
   /*


### PR DESCRIPTION
Intention is to expose two new settings to users:
* E-Ink Screensaver: what behavior to use when display updates are paused
* E-Ink Full Sun: slower, more robust. Hopes to improve outdoor performance for some displays

Neither of these features are implemented just yet. Screensaver code is a work-in-progress: https://github.com/meshtastic/firmware/pull/3477

Changes tested locally with the python CLI; unsure what work is necessary to eventually expose the new settings in the mobile apps / Web UI.