### PR TITLE
Add CDEBYTE_EORA_S3 to mesh.proto HardwareModel enum

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -511,6 +511,11 @@ enum HardwareModel {
   TD_LORAC = 60;
 
   /*
+   * CDEBYTE EoRa-S3 board using their own MM modules, clone of LILYGO T3S3
+   */
+  CDEBYTE_EORA_S3 = 61;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Needed for [adding support for the CDEBYTE_EoRa-S3 variant](https://github.com/meshtastic/firmware/pull/3613).