### PR TITLE
Add status_led_off to support turning status LED off (dark mode)

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -185,6 +185,11 @@ message Config {
      * POSIX Timezone definition string from https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv.
      */
     string tzdef = 11;
+
+    /*
+     * If true, inhibit blinking LED at LED_PIN regularly
+     */
+    bool status_led_off = 12;
   }
 
   /*


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?

Add status_led_off to support turning status LED off (dark mode).

This only affects the GPIO-controllable LED and may be desirable behavior for Meshtastic users who sleep in the vicinity of their node and are annoyed by the blinking LED, especially for boards that indicate charging when USB power is connected, resulting in a 1 second LED illumination cycle.

Most boards however, have a non-GPIO controlled power LED (i.e. hardwired to VBUS/VCC/etc.) that can only be turned off by desoldering or otherwise removing that LED. This can't be addressed by firmware changes.

<!-- Please remove or replace the issue url -->

> [[Feature Request]: Option to turn off LED inducators on ESP32 Heltec V3](https://github.com/meshtastic/firmware/issues/3635)

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
