### PR TITLE
Rebrand as heartbeat led and add more explicit description

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -187,9 +187,9 @@ message Config {
     string tzdef = 11;
 
     /*
-     * If true, inhibit blinking LED at LED_PIN regularly
+     * If true, disable the default blinking LED (LED_PIN) behavior on the device 
      */
-    bool status_led_off = 12;
+    bool led_heartbeat_disabled = 12;
   }
 
   /*


### PR DESCRIPTION
This hopefully calls out that we're not enabling any kind of "dark mode" but rather just turning off of the standard led blinking behavior