### PR TITLE
add HardwareModel: TWC_MESH_V4 to mesh.proto HardwareModel enum

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -515,6 +515,11 @@ enum HardwareModel {
    */
   CDEBYTE_EORA_S3 = 61;
 
+/*
+   * TWC_MESH_V4 
+   * Adafruit NRF52840 feather express with SX1262, SSD1306 OLED and NEO6M GPS
+   */
+  TWC_MESH_V4 = 62;
   /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?

Add  HardwareModel: TWC_MESH_V4  to mesh.proto HardwareModel enum   
[Add new variant: TWC_Mesh #3705](https://github.com/meshtastic/firmware/pull/3705)

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
