### PR TITLE
Added mute channel into module settings

### DIFF
--- a/meshtastic/channel.proto
+++ b/meshtastic/channel.proto
@@ -96,6 +96,12 @@ message ModuleSettings {
    * Bits of precision for the location sent in position packets.
    */
   uint32 position_precision = 1;
+
+  /*
+   * Controls whether or not the phone / clients should mute the current channel
+   * Useful for noisy public channels you don't necessarily want to disable
+   */
+  bool is_client_muted = 2;
 }
 
 /*


### PR DESCRIPTION
This will allow the configuration of a "muted" channel to stay with the device, but be enforced on client / apps
Closes #490 