### PR TITLE
Synchronize ham short_name length with meshtastic user short_name length

### DIFF
--- a/meshtastic/admin.options
+++ b/meshtastic/admin.options
@@ -8,5 +8,5 @@
 *AdminMessage.get_ringtone_response max_size:231
 
 *HamParameters.call_sign max_size:8
-*HamParameters.short_name max_size:6
+*HamParameters.short_name max_size:5
 *NodeRemoteHardwarePinsResponse.node_remote_hardware_pins max_count:16


### PR DESCRIPTION
Synchronize ham short_name length with meshtastic user short_name length

# What does this PR do?

Setting the field length of short_name to 5 instead of 6.

The length of the short name of a meshtastic user is 4. 
The array of chars containg the name has the length of 5 (terminating zero at byte 5).
The short name length and the refelcting field of HAM should not exceed these values.

Note: You cannot set the short name of a user to more than 4 chars via the app, so it should not be a vital issue.
