### PR TITLE
Add ID for Bandit Nano

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -531,6 +531,13 @@ enum HardwareModel {
    * Promicro NRF52840 with SX1262/LLCC68, SSD1306 OLED and NEO6M GPS
    */
   NRF52_PROMICRO_DIY = 63;
+
+  /*
+   * RadioMaster 900 Bandit Nano, https://www.radiomasterrc.com/products/bandit-nano-expresslrs-rf-module
+   * ESP32-D0WDQ6 With SX1276/SKY66122, SSD1306 OLED and No GPS
+   */
+   RADIOMASTER_900_BANDIT_NANO = 64
+   
   /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.


### PR DESCRIPTION
RadioMaster 900 Bandit Nano ID, https://www.radiomasterrc.com/products/bandit-nano-expresslrs-rf-module

<!-- Describe what you are intending to change -->

# What does this PR do?

Add an ID for Radio Master Bandit Nano.

## Checklist before merging

- [*] All top level messages commented
- [*] All enum members have unique descriptions
