### PR TITLE
Ability to disable PA FAN.

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -193,7 +193,7 @@ message Config {
   }
 
     /*
-     * If true, disable the FAN (RF95_FAN_EN) behavior on the device
+     * If true, disable the build-in FAN using pin defind in RF95_FAN_EN.
      */
     bool pa_fan_disabled = 13;
     

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -193,7 +193,7 @@ message Config {
   }
 
     /*
-     * If true, disable the build-in FAN using pin defind in RF95_FAN_EN.
+     * If true, disable the build-in PA FAN using pin define in RF95_FAN_EN.
      */
     bool pa_fan_disabled = 13;
     

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -192,6 +192,11 @@ message Config {
     bool led_heartbeat_disabled = 12;
   }
 
+    /*
+     * If true, disable the FAN (RF95_FAN_EN) behavior on the device
+     */
+    bool pa_fan_disabled = 13;
+    
   /*
    * Position Config
    */


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?
Options to disable FAN useful in areas with low traffic it's indented for the Radio Master 900 Bandit Nano where 
a FAN is build-in to cool the PA.

## Checklist before merging

- [*] All top level messages commented
- [*] All enum members have unique descriptions
