### PR TITLE
Add Heltec HRU-3601

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -335,6 +335,11 @@ enum HardwareModel {
   RAK2560 = 22;
 
   /*
+   * Heltec HRU-3601: https://heltec.org/project/hru-3601/
+   */
+  HELTEC_HRU_3601 = 23;
+
+  /*
    * B&Q Consulting Station Edition G1: https://uniteng.com/wiki/doku.php?id=meshtastic:station
    */
   STATION_G1 = 25;


### PR DESCRIPTION
A product built around the HT-CT62 module (ESP32-C3 CPU and SX1262 LoRa) and SKUs with various sensors. A separate variant is needed due to re-use of GPIOs for LEDs, user button, power gating to the I2C peripheral, etc.

https://heltec.org/project/hru-3601/