### PR TITLE
Disable PA FAN Pin if needed in a low traffic area.

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -191,6 +191,10 @@ message Config {
      */
     bool led_heartbeat_disabled = 12;
   }
+    /*
+     * If true, disable the build-in PA FAN using pin define in RF95_FAN_EN.
+     */
+    bool pa_fan_disabled = 13;
 
   /*
    * Position Config


### PR DESCRIPTION
To be used for disable build-in FAN on some devices like RadioMaster Bandit Micro/Nano if needed in a low traffic area.

- [X] All top level messages commented
- [X] All enum members have unique descriptions
