### PR TITLE
Add FileInfo packet to FromRadio

### DIFF
--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -43,6 +43,8 @@
 *LogRecord.message max_size:64
 *LogRecord.source max_size:8
 
+*FileInfo.file_name max_size:228
+
 # MyMessage.name         max_size:40 
 # or fixed_length or fixed_count, or max_count
 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1459,7 +1459,27 @@ message FromRadio {
      * MQTT Client Proxy Message (device sending to client / phone for publishing to MQTT)
      */
     MqttClientProxyMessage mqttClientProxyMessage = 14;
+
+    /*
+     * File system manifest messages
+     */
+    FileInfo fileInfo = 15;
   }
+}
+
+/*
+ * Individual File info for the device
+ */
+message FileInfo {
+  /*
+   * The fully qualified path of the file
+   */
+  string file_name = 1;
+
+  /*
+   * The size of the file in bytes
+   */
+  uint32 size_bytes = 2;
 }
 
 /*


### PR DESCRIPTION
These will be sent up on want_config flow to inform clients of the device's file system manifest file-by-file.