### PR TITLE
Add Heltec new boards

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -574,7 +574,7 @@ enum HardwareModel {
   HELTEC_VISION_MASTER_E290 = 68;
    
    /*
-   * Heltec Mesh Node T114 borad with nRF52840 CPU, and a 1.14 inch TFT display, Ultimate low-power design,
+   * Heltec Mesh Node T114 board with nRF52840 CPU, and a 1.14 inch TFT display, Ultimate low-power design,
    * specifically adapted for the Meshtatic project
    */
   HELTEC_MESH_NODE_T114 = 69;

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -558,6 +558,27 @@ enum HardwareModel {
    */
   HELTEC_CAPSULE_SENSOR_V3 = 65;
    
+   /*
+   * Heltec Vision Master T190 with ESP32-S3 CPU, and a 1.90 inch TFT display
+   */
+  HELTEC_VISION_MASTER_T190 = 66;
+   
+   /*
+   * Heltec Vision Master E213 with ESP32-S3 CPU, and a 2.13 inch E-Ink display
+   */
+  HELTEC_VISION_MASTER_E213 = 67;
+   
+   /*
+   * Heltec Vision Master E290 with ESP32-S3 CPU, and a 2.9 inch E-Ink display
+   */
+  HELTEC_VISION_MASTER_E290 = 68;
+   
+   /*
+   * Heltec Mesh Node T114 borad with nRF52840 CPU, and a 1.14 inch TFT display, Ultimate low-power design,
+   * specifically adapted for the Meshtatic project
+   */
+  HELTEC_MESH_NODE_T114 = 69;
+  
   /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.


### PR DESCRIPTION
Added 4 Heltec New boards.

- Vision Master T190 -- ESP32-S3 CPU, and a 1.90-inch TFT display
- [Vision Master E213](https://heltec.org/project/vision-master-e213/) -- ESP32-S3 CPU, and a 2.13-inch E-Ink display
- [Vision Master E290](https://heltec.org/project/vision-master-e290/) -- ESP32-S3 CPU, and a 2.9-inch E-Ink display
- Mesh Node T114 -- nRF52840 CPU, and a 1.14-inch TFT display, Ultimate low-power design, specifically adapted for the Meshtatic project