### PR TITLE
Remove unnecessary import

### DIFF
--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -5,7 +5,6 @@ package meshtastic;
 import "meshtastic/channel.proto";
 import "meshtastic/localonly.proto";
 import "meshtastic/mesh.proto";
-import "meshtastic/module_config.proto";
 import "meshtastic/telemetry.proto";
 import "nanopb.proto";
 


### PR DESCRIPTION
# What does this PR do?

This change removes an unnecessary import statement in one of the protobuf files. When I generated protos on the Apple clients, I kept getting this message...

```
➜  Meshtastic-Apple (2.3.12_Working_Changes) ✔ ./scripts/gen_protos.sh
meshtastic/deviceonly.proto:8:1: warning: Import meshtastic/module_config.proto is unused.
Done generating the swift files from the proto files.
Build, test, and commit changes.
```

I'd like to figure out if this is an actual issue with the protobuf definitions, or if the codegen is busted.