### PR TITLE
Add bool to StoreForward config to set it as server

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -468,6 +468,11 @@ message ModuleConfig {
      * TODO: REPLACE
      */
     uint32 history_return_window = 5;
+
+    /*
+     * Set to true to let this node act as a server that stores received messages and resends them upon request.
+     */
+    bool is_server = 6;
   }
 
   /*


### PR DESCRIPTION
This adds a boolean option to set a node as StoreForward server. 
I think the restriction to set the node as `ROUTER` in order to be a StoreForward server is outdated, especially now that `ROUTER_CLIENT` is deprecated. A node that is good at sniffing packets to store them is not necessarily a good node to hop over. For example, I have a T-Beam in my house that acts as StoreForward server in `ROUTER_CLIENT` role for when I come home with my mobile node, but my RAK on the roof would be much better to hop over.