### PR TITLE
add ws85 serialmodule mode, add gust,lull to env telemetry

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -304,6 +304,8 @@ message ModuleConfig {
       NMEA = 4;
       // NMEA messages specifically tailored for CalTopo
       CALTOPO = 5;
+      // Ecowitt WS85 weather station
+      WS85 = 6;
     }
 
     /*

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -118,6 +118,16 @@ message EnvironmentMetrics {
    * Weight in KG
    */
   float weight = 15;
+
+  /*
+   * Wind gust in m/s
+   */
+  float wind_gust = 15;
+
+  /*
+   * Wind lull in m/s
+   */
+  float wind_lull = 16;
 }
 
 /*


### PR DESCRIPTION
To enable a special SerialModule mode to work with the WS85 weather station from ecowitt I had added the WS85 serial mode and added the wind_gust and wind_lull fields to the environmental_telemetry protobuf
