### PR TITLE
Revert "LogRecord over serial enabled"

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -192,11 +192,6 @@ message Config {
      * If true, disable the default blinking LED (LED_PIN) behavior on the device 
      */
     bool led_heartbeat_disabled = 12;
-    
-    /*
-     * Enable LogRecord messages over Serial for API connections
-     */
-    bool logrecord_serial_enabled = 13;
   }
 
   /*


### PR DESCRIPTION
Reverts meshtastic/protobufs#537

As @andrekir pointed out, we actually already account for this! But we had a bit of a mix up in the latest refactor.