### PR TITLE
Additional Telemetry sensors - BMP388, ICM-20948, MAX17048

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -395,6 +395,21 @@ enum TelemetrySensorType {
    * NAU7802 Scale Chip or compatible
    */
   NAU7802 = 25;
+
+  /*
+   * BMP3XX High accuracy temperature and pressure
+   */
+  BMP3XX = 26;
+
+  /*
+   * ICM-20948 9-Axis digital motion processor
+   */
+  ICM20948 = 27;
+
+  /*
+   * MAX17048 1S lipo battery sensor (voltage, state of charge, time to go)
+   */
+  MAX17048 = 28;
 }
 
 /*


### PR DESCRIPTION
This adds enums for new sensor types in the Telemetry module:
- BMP3XX - high accuracy temperature and pressure (n.b. an upgrade from BMP-280)
- ICM-20948 9-Axis digital motion processor (n.b. an upgrade from MPU-6050)
- MAX17048 1S lipo battery sensor provides voltage, state of charge, and time to go (n.b. gives the rate of discharge which is great for battery powered devices)

There is no impact or changes to existing sensors

Appreciate if you can merge this PR into the mestastic protobufs, and I'll raise another for the meshtastic firmware to add these new sensors to the Telemetry module

- [x] All top level messages commented
- [x] All enum members have unique descriptions
