### PR TITLE
Add  a "battery_time_to_go_seconds" field to DeviceMetrics

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -36,6 +36,11 @@ message DeviceMetrics {
    * How long the device has been running since the last reboot (in seconds)
    */
   uint32 uptime_seconds = 5;
+
+  /*
+   * Time remaining for the battery to charge/discharge in seconds
+   */
+  uint32 battery_time_to_go_seconds = 6;
 }
 
 /*


### PR DESCRIPTION
"How long do I have before my battery dies" is a critical parameter for portable devices

This PR adds a field "battery_time_to_go_seconds" to DeviceMetrics to signal this parameter

Separately I've raised PR [#540](https://github.com/meshtastic/protobufs/pull/540) to add the MAX17048 lipo fuel gauge as an I2C sensor, which then allows us to easily approximate time-to-go based on the lipo charge/discharge rate. 

- [x] All top level messages commented
- [x] All enum members have unique descriptions
