### PR TITLE
Add RAK3172 and Wio-E5 STM32WL-based hardware models

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -590,6 +590,16 @@ enum HardwareModel {
   TRACKER_T1000_E = 71;
   
   /*
+   * RAK3172 STM32WLE5 Module (https://store.rakwireless.com/products/wisduo-lpwan-module-rak3172)
+   */
+  RAK3172 = 72;
+
+  /*
+   * Seeed Studio Wio-E5 (either mini or Dev kit) using STM32WL chip.
+   */
+  WIO_E5 = 73;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
These fit in flash now and at least for the Wio-E5 I confirmed you can configure your region with the userPrefs file to send and receive messages.
