### PR TITLE
Add NONE_PKI error message

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -753,6 +753,11 @@ message Routing {
      * (i.e you did not send the request on the required bound channel)
      */
     NOT_AUTHORIZED = 33;
+
+    /*
+     * This message is not a failure, and indicates that the message was sent via PKI
+     */
+    NONE_PKI = 34;
   }
 
   oneof variant {


### PR DESCRIPTION
This error message should be interpreted as not an error, and also as an indicator that an outgoing message was sent via PKI.