### PR TITLE
Edit Comments of Canned Messages

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -658,7 +658,7 @@ message ModuleConfig {
 
     /*
      * Input event origin accepted by the canned message module.
-     * Can be e.g. "rotEnc1", "upDownEnc1" or keyword "_any"
+     * Can be e.g. "rotEnc1", "upDownEnc1", "scanAndSelect", "cardkb", "serialkb", or keyword "_any"
      */
     string allow_input_source = 10;
 


### PR DESCRIPTION
This PR adds import sources, based on the docs, to the comments of the Canned Messages allow_input_source in module_config.proto:
-scanAndSelect
-cardkb
-serialkb

Marking as a draft because I don't know if this is useful 😁