### PR TITLE
Adds Admin session_passkey to prevent replay of admin packets

### DIFF
--- a/meshtastic/admin.options
+++ b/meshtastic/admin.options
@@ -1,5 +1,7 @@
 *AdminMessage.payload_variant anonymous_oneof:true
 
+*AdminMessage.session_passkey max_size:8
+
 *AdminMessage.set_canned_message_module_messages max_size:201
 *AdminMessage.get_canned_message_module_messages_response max_size:201
 *AdminMessage.delete_file_request max_size:201

--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -23,7 +23,7 @@ message AdminMessage {
 
   /*
    * The node generates this key and sends it with any get_x_response packets.
-   * The client MUST include the same key with any set_x commands. Key expires after 120 seconds.
+   * The client MUST include the same key with any set_x commands. Key expires after 300 seconds.
    * Prevents replay attacks for admin messages.
    */
   bytes session_passkey = 101;

--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -20,6 +20,14 @@ option swift_prefix = "";
  * (Prior to 1.2 these operations were done via special ToRadio operations)
  */
 message AdminMessage {
+
+  /*
+   * The node generates this key and sends it with any get_x_response packets.
+   * The client MUST include the same key with any set_x commands. Key expires after 120 seconds.
+   * Prevents replay attacks for admin messages.
+   */
+  bytes session_passkey = 101;
+
   /*
    * TODO: REPLACE
    */


### PR DESCRIPTION
Adds a session passkey for admin operations. When the remote node responds to any get_x request, it will include the session passkey in the response. When the local client tries to make any admin changes, the remote node expects that session key to be set. The session key will expire after a short time, currently 120 seconds.