### PR TITLE
Add route back and SNR lists to RouteDiscovery for traceroute

### DIFF
--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -9,6 +9,11 @@
 *User.short_name max_size:5
 
 *RouteDiscovery.route max_count:8
+*RouteDiscovery.snr_towards max_count:8
+*RouteDiscovery.snr_towards int_size:8
+*RouteDiscovery.route_back max_count:8
+*RouteDiscovery.snr_back max_count:8
+*RouteDiscovery.snr_back int_size:8
 
 # note: this payload length is ONLY the bytes that are sent inside of the Data protobuf (excluding protobuf overhead). The 16 byte header is
 # outside of this envelope

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -695,13 +695,28 @@ message User {
 }
 
 /*
- * A message used in our Dynamic Source Routing protocol (RFC 4728 based)
+ * A message used in a traceroute
  */
 message RouteDiscovery {
   /*
-   * The list of nodenums this packet has visited so far
+   * The list of nodenums this packet has visited so far to the destination.
    */
   repeated fixed32 route = 1;
+
+  /*
+   * The list of SNRs (in dB, scaled by 4) in the route towards the destination.
+   */
+  repeated int32 snr_towards = 2;
+
+  /*
+   * The list of nodenums the packet has visited on the way back from the destination.
+   */
+  repeated fixed32 route_back = 3;
+
+  /*
+   * The list of SNRs (in dB, scaled by 4) in the route back from the destination.
+   */
+  repeated int32 snr_back = 4;
 }
 
 /*

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -174,7 +174,7 @@ enum PortNum {
 
   /*
    * Provides a traceroute functionality to show the route a packet towards
-   * a certain destination would take on the mesh.
+   * a certain destination would take on the mesh. Contains a RouteDiscovery message as payload.
    * ENCODING: Protobuf
    */
   TRACEROUTE_APP = 70;


### PR DESCRIPTION
In order to get two-way information with SNR per hop in a traceroute, this adds another list of nodenums `route_back` and two lists of 1-byte SNR values (in dB, but scaled by 4, so e.g. a value of -64 is -16dB), namely `snr_towards` and `snr_back`.

This should allow us to visualize a traceroute from node 0x10 to 0x13 as:
```
0x10 --> 0x11 (-5.00dB) --> 0x12 (-4.00dB) --> 0x13 (7.00dB)
(-5.00dB) 0x10 <-- (-4.00dB) 0x11 <-- (7.00dB) 0x12 <-- 0x13
```
