### PR TITLE
Make admin_key repeated max count 1, for future expansion

### DIFF
--- a/meshtastic/config.options
+++ b/meshtastic/config.options
@@ -19,3 +19,4 @@
 *SecurityConfig.public_key max_size:32
 *SecurityConfig.private_key max_size:32
 *SecurityConfig.admin_key max_size:32
+*SecurityConfig.admin_key max_count:1

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -1026,7 +1026,7 @@ message Config {
     /*
      * The public key authorized to send admin messages to this node.
      */
-    bytes admin_key = 3;
+    repeated bytes admin_key = 3;
 
     /*
      * If true, device is considered to be "managed" by a mesh administrator via admin messages


### PR DESCRIPTION
We might want to allow multiple admin keys for remote administration. This makes it an easier change to do so if we choose to.