### PR TITLE
Add new MeshPacket priority HIGH

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1021,6 +1021,11 @@ message MeshPacket {
     RELIABLE = 70;
 
     /*
+     * Higher priority for specific message types (portnums) to distinguish between other reliable packets.
+     */ 
+    HIGH = 100;
+
+    /*
      * Ack/naks are sent with very high priority to ensure that retransmission
      * stops as soon as possible
      */


### PR DESCRIPTION
For https://github.com/meshtastic/firmware/issues/4576

I considered it calling `TEXT`, but maybe in the future it suits for different portnums as well.
Gave it the value 100 such that there's still some room between `RELIABLE` and `HIGH` (e.g. for `MEDIUM`) and between `HIGH` and `ACK`, e.g. for `CRITICAL`. 
