### PR TITLE
Adds OKToMqtt bool to data

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -973,6 +973,11 @@ message Config {
      * If true, the device will not process any packets received via LoRa that passed via MQTT anywhere on the path towards it.
      */
     bool ignore_mqtt = 104;
+
+    /*
+     * Sets the ok_to_mqtt bit on outgoing packets
+     */
+    bool config_ok_to_mqtt = 105;
   }
 
   message BluetoothConfig {

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -888,6 +888,11 @@ message Data {
    * a message a heart or poop emoji.
    */
   fixed32 emoji = 8;
+
+  /*
+   * Defaults to false. Indicates the user approves the packet being uploaded to MQTT.
+   */
+  bool OKToMqtt = 9;
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -892,7 +892,7 @@ message Data {
   /*
    * Defaults to false. Indicates the user approves the packet being uploaded to MQTT.
    */
-  bool OKToMqtt = 9;
+  optional bool ok_to_mqtt = 9;
 }
 
 /*


### PR DESCRIPTION
Implements part of https://github.com/meshtastic/rfcs/blob/position-mqtt-privacy/rfcs/2024-08-30-position-privacy.md. This adds a bit to each data protobuf, indicating that the user consents to uploading their data to a public MQTT broker. Without this bit set to true, for the public channel, the firmware will refuse to upload packets to MQTT, and our MQTT broker will refuse to process the packets.