### PR TITLE
add fixed_position, ringtone, and canned_messages to `DeviceProfile`

### DIFF
--- a/meshtastic/clientonly.options
+++ b/meshtastic/clientonly.options
@@ -1,2 +1,4 @@
 *DeviceProfile.long_name max_size:40
 *DeviceProfile.short_name max_size:5
+*DeviceProfile.ringtone max_size:231
+*DeviceProfile.canned_messages max_size:201

--- a/meshtastic/clientonly.proto
+++ b/meshtastic/clientonly.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package meshtastic;
 
 import "meshtastic/localonly.proto";
+import "meshtastic/mesh.proto";
 
 option csharp_namespace = "Meshtastic.Protobufs";
 option go_package = "github.com/meshtastic/go/generated";
@@ -39,4 +40,19 @@ message DeviceProfile {
    * The ModuleConfig of the node
    */
   optional LocalModuleConfig module_config = 5;
+
+  /*
+   * Fixed position data
+   */
+  optional Position fixed_position = 6;
+
+  /*
+   * Ringtone for ExternalNotification
+   */
+  optional string ringtone = 7;
+
+  /*
+   * Predefined messages for CannedMessage
+   */
+  optional string canned_messages = 8;
 }


### PR DESCRIPTION
adds `fixed_position`, `ringtone`, and `canned_messages` fields to `DeviceProfile` for export/import functionality.