### PR TITLE
convert hops_away from required to optional

### DIFF
--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -141,7 +141,7 @@ message NodeInfoLite {
   /*
    * Number of hops away from us this node is (0 if adjacent)
    */
-  uint32 hops_away = 9;
+  optional uint32 hops_away = 9;
 
   /*
    * True if node is in our favorites list

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1306,7 +1306,7 @@ message NodeInfo {
   /*
    * Number of hops away from us this node is (0 if adjacent)
    */
-  uint32 hops_away = 9;
+  optional uint32 hops_away = 9;
 
   /*
    * True if node is in our favorites list


### PR DESCRIPTION


# What does this PR do?
convert hops_away from required to optional

This will enable feature work to differentiate between hops_away not available and hops_away is zero

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
