### PR TITLE
Adds the hasPKC bool to device metadata capabilities

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1828,6 +1828,11 @@ message DeviceMetadata {
    * Has Remote Hardware enabled
    */
   bool hasRemoteHardware = 10;
+
+  /*
+   * Has PKC capabilities
+   */
+  bool hasPKC = 11;
 }
 
 /*


### PR DESCRIPTION
Hitting an odd case with clients, that don't realize old nodes don't support Public Key DMs.