### PR TITLE
Implement more flexible triggering in DetectionSensor

### DIFF
--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -26,3 +26,4 @@
 
 *DetectionSensorConfig.monitor_pin int_size:8
 *DetectionSensorConfig.name max_size:20
+*DetectionSensorConfig.detection_trigger_type max_size:8

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -137,20 +137,39 @@ message ModuleConfig {
    * Detection Sensor Module Config
    */
   message DetectionSensorConfig {
+
+    enum TriggerType {
+      // Event is triggered if pin is low
+      LOGIC_LOW = 0;
+      // Event is triggered if pin is high
+      LOGIC_HIGH = 1;
+      // Event is triggered when pin goes high to low
+      FALLING_EDGE = 2;
+      // Event is triggered when pin goes low to high
+      RISING_EDGE = 3;
+      // Event is triggered on every pin state change, low is considered to be
+      // "active"
+      EITHER_EDGE_ACTIVE_LOW = 4;
+      // Event is triggered on every pin state change, high is considered to be
+      // "active"
+      EITHER_EDGE_ACTIVE_HIGH = 5;
+    }
     /*
      * Whether the Module is enabled
      */
     bool enabled = 1;
 
     /*
-     * Interval in seconds of how often we can send a message to the mesh when a state change is detected
+     * Interval in seconds of how often we can send a message to the mesh when a
+     * trigger event is detected
      */
     uint32 minimum_broadcast_secs = 2;
 
     /*
-     * Interval in seconds of how often we should send a message to the mesh with the current state regardless of changes
-     * When set to 0, only state changes will be broadcasted
-     * Works as a sort of status heartbeat for peace of mind
+     * Interval in seconds of how often we should send a message to the mesh
+     * with the current state regardless of trigger events When set to 0, only
+     * trigger events will be broadcasted Works as a sort of status heartbeat
+     * for peace of mind
      */
     uint32 state_broadcast_secs = 3;
 
@@ -173,23 +192,15 @@ message ModuleConfig {
     uint32 monitor_pin = 6;
 
     /*
-     * Whether or not the GPIO pin state detection is triggered on HIGH (1)
-     * Otherwise LOW (0)
+     * The type of trigger event to be used
      */
-    bool detection_triggered_high = 7;
+    TriggerType detection_trigger_type = 7;
 
     /*
      * Whether or not use INPUT_PULLUP mode for GPIO pin
      * Only applicable if the board uses pull-up resistors on the pin
      */
     bool use_pullup = 8;
-
-    /*
-     * Whether or not all the state transition should be broadcasted.
-     * Causes an additional message to be sent to mesh when detection state goes
-     * back to false.
-     */
-    bool broadcast_all_state_transitions = 9;
   }
 
   /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -183,6 +183,13 @@ message ModuleConfig {
      * Only applicable if the board uses pull-up resistors on the pin
      */
     bool use_pullup = 8;
+
+    /*
+     * Whether or not all the state transition should be broadcasted.
+     * Causes an additional message to be sent to mesh when detection state goes
+     * back to false.
+     */
+    bool broadcast_all_state_transitions = 9;
   }
 
   /*


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?

Add support for meshtastic/firmware#4753, see meshtastic/firmware#4776 for additional context

`DetectionSensorConfig.detection_trigger_type` supersedes `detection_triggered_high` keeping same tag because both bools and enums are internally represented as varints

## Checklist before merging

- [X] All top level messages commented
- [X] All enum members have unique descriptions
