### PR TITLE
Add MLX90614 non-contact IR temperature sensor.

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -515,8 +515,6 @@ enum TelemetrySensorType {
    * MLX90614 non-contact IR temperature sensor.
    */
   MLX90614 = 31;
-
-  /*
 }
 
 /*

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -510,6 +510,13 @@ enum TelemetrySensorType {
    * MAX30102 Pulse Oximeter and Heart-Rate Sensor 
    */
   MAX30102 = 30;
+  
+  /*
+   * MLX90614 non-contact IR temperature sensor.
+   */
+  MLX90614 = 31;
+
+  /*
 }
 
 /*


### PR DESCRIPTION
Mentioned in https://github.com/meshtastic/firmware/issues/4738 as being most appropriate for sensing animal temperature. 

Also, according to https://www.sparkfun.com/products/retired/14569, a replacement for the apparently retired MLX90632
