### PR TITLE
Rename M5STACK_CORE to prepare for M5STACK_CORE2 and M5STACK_CORES3

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -434,7 +434,7 @@ enum HardwareModel {
   /*
    * M5 esp32 based MCU modules with enclosure, TFT and LORA Shields. All Variants (Basic, Core, Fire, Core2, CoreS3, Paper) https://m5stack.com/
    */
-  M5STACK = 42;
+  M5STACK_CORE = 42;
 
   /*
    * New Heltec LoRA32 with ESP32-S3 CPU


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?
Rename to `M5STACK_CORE` to prepare for `M5STACK_CORE2` and `M5STACK_CORES3`

[Related PR](https://github.com/meshtastic/firmware/pull/5008)

## Checklist before merging

- [X] All top level messages commented
- [X] All enum members have unique descriptions
