### PR TITLE
Add rebroadcast mode to ignore non-standard portnum traffic

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -131,6 +131,12 @@ message Config {
        * Only permitted for SENSOR, TRACKER and TAK_TRACKER roles, this will inhibit all rebroadcasts, not unlike CLIENT_MUTE role.
        */
       NONE = 4;
+
+      /*
+       * Ignores packets from non-standard portnums such as: TAK, RangeTest, PaxCounter, etc.
+       * Only rebroadcasts packets with standard portnums: NodeInfo, Text, Position, Telemetry, and Routing.
+       */
+      CORE_PORTNUMS_ONLY = 5;
     }
 
     /*


### PR DESCRIPTION
Enables a bit more traffic management on the mesh. This will essentially unlock what we did for EVENT_MODE at DefCon as a configuration. IMO, setting the Role of Repeater or Router should default to this once implemented in order to curb over-utilization of preferred routers with non-standard traffic.