### PR TITLE
(Detection Sensor Module) Send message to channel/node not public

### DIFF
--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -27,4 +27,3 @@
 *DetectionSensorConfig.monitor_pin int_size:8
 *DetectionSensorConfig.name max_size:20
 *DetectionSensorConfig.detection_trigger_type max_size:8
-*DetectionSensorConfig.sendTo max_size:12

--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -27,3 +27,4 @@
 *DetectionSensorConfig.monitor_pin int_size:8
 *DetectionSensorConfig.name max_size:20
 *DetectionSensorConfig.detection_trigger_type max_size:8
+*DetectionSensorConfig.sendTo max_size:12

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -201,13 +201,17 @@ message ModuleConfig {
      * Only applicable if the board uses pull-up resistors on the pin
      */
     bool use_pullup = 8;
+ 
+   /*
+    * If this is set true, messages are send as a direct message to the NodeNum set in "sendTo". 
+    * If set to false, messages are broadcasted to a channel with the index set in "sendTo".
+    */
+    bool send_as_dm = 9;
 
-    /* If this is set, message are send to channel set in "sendTo" else a "NodeID"*/
-    bool sendAsDM = 9;
-
-    /* Send module messages to Channel Index/UserID.
+    /*
+     * Send module messages to Channel Index/NodeNum.
      * Example: A number set as "1" would result in a message send to channel index "1" if sendToChannel is set
-     * Example: A number of "0x11111111" would result in a message send to UserID "0x11111111" if sendToChannel is not set
+     * Example: A number of "0x11111111" would result in a message send to NodeNum "0x11111111" if sendToChannel is not set
      */
     uint32 sendTo = 10;
   }

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -209,7 +209,7 @@ message ModuleConfig {
      * Example: A number set as "1" would result in a message send to channel index "1" if sendToChannel is set
      * Example: A number of "FFFFFFFF" would result in a message send to UserID "FFFFFFFF" if sendToChannel is not set
      */
-    uint32_t sendTo = 10;
+    uint32 sendTo = 10;
   }
 
   /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -203,11 +203,11 @@ message ModuleConfig {
     bool use_pullup = 8;
 
     /* If this is set, message are send to channel set in "sendTo" else a "NodeID"*/
-    bool sendTochannel = 9;
+    bool sendAsDM = 9;
 
     /* Send module messages to Channel Index/UserID.
      * Example: A number set as "1" would result in a message send to channel index "1" if sendToChannel is set
-     * Example: A number of "FFFFFFFF" would result in a message send to UserID "FFFFFFFF" if sendToChannel is not set
+     * Example: A number of "0x11111111" would result in a message send to UserID "0x11111111" if sendToChannel is not set
      */
     uint32 sendTo = 10;
   }

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -205,12 +205,11 @@ message ModuleConfig {
     /* If this is set, message are send to channel set in "sendTo" else a "NodeID"*/
     bool sendTochannel = 9;
 
-    /* Send module messages to Channel/Node.
-     * Example: A name "Detection" would result in a message send to channel "Detection" if sendToChannel **is** set
-     * Example: A name "01020304" would result in a message send to node "01020304" if sendToChannel is **not** set
-     * Maximum length of 12 characters
+    /* Send module messages to Channel Index/UserID.
+     * Example: A number set as "1" would result in a message send to channel index "1" if sendToChannel is set
+     * Example: A number of "FFFFFFFF" would result in a message send to UserID "FFFFFFFF" if sendToChannel is not set
      */
-    string sendTo = 10;
+    uint32_t sendTo = 10;
   }
 
   /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -203,8 +203,8 @@ message ModuleConfig {
     bool use_pullup = 8;
  
    /*
-    * If this is set true, messages are send as a direct message to the NodeNum set in "sendTo". 
-    * If set to false, messages are broadcasted to a channel with the index set in "sendTo".
+    * If this is set true, messages are send as a direct message to the NodeNum set in "send_to". 
+    * If set to false, messages are broadcasted to a channel with the index set in "send_to".
     */
     bool send_as_dm = 9;
 
@@ -213,7 +213,7 @@ message ModuleConfig {
      * Example: A number set as "1" would result in a message send to channel index "1" if sendToChannel is set
      * Example: A number of "0x11111111" would result in a message send to NodeNum "0x11111111" if sendToChannel is not set
      */
-    uint32 sendTo = 10;
+    uint32 send_to = 10;
   }
 
   /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -210,8 +210,8 @@ message ModuleConfig {
 
     /*
      * Send module messages to Channel Index/NodeNum.
-     * Example: A number set as "1" would result in a message send to channel index "1" if sendToChannel is set
-     * Example: A number of "0x11111111" would result in a message send to NodeNum "0x11111111" if sendToChannel is not set
+     * Example: A number set as "1" would result in a message send to channel index "1" if send_as_dm is set false
+     * Example: A number of "0x11111111" would result in a message send to NodeNum "0x11111111" if send_as_dm is set true
      */
     uint32 send_to = 10;
   }

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -201,6 +201,16 @@ message ModuleConfig {
      * Only applicable if the board uses pull-up resistors on the pin
      */
     bool use_pullup = 8;
+
+    /* If this is set, message are send to channel set in "sendTo" else a "NodeID"*/
+    bool sendTochannel = 9;
+
+    /* Send module messages to Channel/Node.
+     * Example: A name "Detection" would result in a message send to channel "Detection" if sendToChannel **is** set
+     * Example: A name "01020304" would result in a message send to node "01020304" if sendToChannel is **not** set
+     * Maximum length of 12 characters
+     */
+    string sendTo = 10;
   }
 
   /*


### PR DESCRIPTION
Theses change are a part of preventing spamming messages from Detection Sensor Module on Public channel.
PR coming to Meshtastic firmware as well.

**sendTo** - Can be a Channel name or NodeID
**sendTochannel** - If true, messages will be redirected to channel but blocked if it's Public.

- [X] All top level messages commented
- [X] All enum members have unique descriptions
