### PR TITLE
Add bool to enable LoRa transport for NeighborInfo

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -128,9 +128,14 @@ message ModuleConfig {
 
     /*
      * Interval in seconds of how often we should try to send our
-     * Neighbor Info to the mesh
+     * Neighbor Info (minimum is 14400, i.e., 4 hours)
      */
     uint32 update_interval = 2;
+
+    /*
+     * Whether in addition to sending it to MQTT and the PhoneAPI, our NeighborInfo should be transmitted over LoRa.
+     */
+    bool transmit_over_lora = 3; 
   }
 
   /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -134,6 +134,7 @@ message ModuleConfig {
 
     /*
      * Whether in addition to sending it to MQTT and the PhoneAPI, our NeighborInfo should be transmitted over LoRa.
+     * Note that this is not available on a channel with default key and name.
      */
     bool transmit_over_lora = 3; 
   }


### PR DESCRIPTION
As discussed in https://github.com/meshtastic/firmware/issues/5082.

This will default to false. Only needs to be enabled when NeighborInfo from remote nodes is wanted.


