### PR TITLE
Add is_ignored bool field to NodeInfo

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -351,6 +351,16 @@ message AdminMessage {
     DeviceUIConfig store_ui_config = 46;
 
     /*
+     * Set specified node-num to be ignored on the NodeDB on the device
+     */
+    uint32 set_ignored_node = 47;
+
+    /*
+     * Set specified node-num to be un-ignored on the NodeDB on the device
+     */
+    uint32 remove_ignored_node = 48;
+
+    /*
      * Begins an edit transaction for config, module config, owner, and channel settings changes
      * This will delay the standard *implicit* save to the file system and subsequent reboot behavior until committed (commit_edit_settings)
      */

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -147,6 +147,12 @@ message NodeInfoLite {
    * Persists between NodeDB internal clean ups
    */
   bool is_favorite = 10;
+
+  /*
+   * True if node is in our ignored list
+   * Persists between NodeDB internal clean ups
+   */
+  bool is_ignored = 11;
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1350,6 +1350,12 @@ message NodeInfo {
    * Persists between NodeDB internal clean ups
    */
   bool is_favorite = 10;
+
+  /*
+   * True if node is in our ignored list
+   * Persists between NodeDB internal clean ups
+   */
+  bool is_ignored = 11;
 }
 
 /*


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

Adds an `is_ignored` flag to the NodeInfo structs. This can be set and unset with admin messages just like the current `is_favorite` flag. This flag is for adding support for ignoring packets from nodes, like the `ignore_incoming` array but without being limited to 3 entries.

I will attempt to create a matching pull request in the firmware project for the firmware-side changes.

<!-- Please remove or replace the issue url -->

> [Related Issue](https://github.com/meshtastic/firmware/issues/5297)

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
