### PR TITLE
Required additions for NextHopRouter

### DIFF
--- a/meshtastic/deviceonly.options
+++ b/meshtastic/deviceonly.options
@@ -10,6 +10,7 @@
 
 *NodeInfoLite.channel int_size:8
 *NodeInfoLite.hops_away int_size:8
+*NodeInfoLite.next_hop int_size:8
 
 *UserLite.long_name max_size:40
 *UserLite.short_name max_size:5

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -153,6 +153,11 @@ message NodeInfoLite {
    * Persists between NodeDB internal clean ups
    */
   bool is_ignored = 11;
+
+  /*
+   * Last byte of the node number of the node that should be used as the next hop to reach this node. 
+   */
+  uint32 next_hop = 12;
 }
 
 /*

--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -38,6 +38,8 @@
 *MeshPacket.hop_limit int_size:8
 *MeshPacket.hop_start int_size:8
 *MeshPacket.channel int_size:8
+*MeshPacket.next_hop int_size:8
+*MeshPacket.relay_node int_size:8
 
 *QueueStatus.res int_size:8
 *QueueStatus.free int_size:8

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1233,6 +1233,18 @@ message MeshPacket {
    * Indicates whether the packet was en/decrypted using PKI
    */
   bool pki_encrypted = 17;
+
+  /*
+   * Last byte of the node number of the node that should be used as the next hop in routing. 
+   * Set by the firmware internally, clients are not supposed to set this.
+   */
+  uint32 next_hop = 18;
+
+  /*
+   * Last byte of the node number of the node that will relay/relayed this packet.
+   * Set by the firmware internally, clients are not supposed to set this.
+   */
+  uint32 relay_node = 19;
 }
 
 /*


### PR DESCRIPTION
These are the required additions for https://github.com/meshtastic/firmware/pull/2856.

It adds the `next_hop` and `relay_node` byte to the MeshPacket, which are used only by the firmware. Furthermore, the `next_hop` will be stored per node in the NodeDB on the device.
