### PR TITLE
Support for the ClimateGuard RadSens Geiger-Muller tube

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -128,6 +128,12 @@ message EnvironmentMetrics {
    * Wind lull in m/s
    */
   optional float wind_lull = 17;
+
+  /*
+  * Radiation in µR/h
+  */
+  optional float radiation = 18;
+
 }
 
 /*
@@ -525,6 +531,12 @@ enum TelemetrySensorType {
    * SCD40/SCD41 CO2, humidity, temperature sensor
    */
   SCD4X = 32;
+
+  /*
+   * ClimateGuard RadSens, radiation, Geiger-Muller Tube
+   */
+  RADSENS = 33;
+
 }
 
 /*


### PR DESCRIPTION
This PR is to support the [ClimateGuard RadSense dosimeter](https://github.com/climateguard/RadSens/blob/master/extras/datasheets/RadSens_datasheet_ENG.pdf).
This is an I2C device which integrates nicely into the firmware along side other sensors.

- Added `radiation` to `EnvironmentMetrics` to hold the measurement in micro-roentgen
- Added `RADSENS` to `TelemetrySensorType`

These changes will support a future pull request to the meshtastic firmware to add support for this device.

Thanks for your consideration.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
