### PR TITLE
update payload max length

### DIFF
--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -17,7 +17,7 @@
 
 # note: this payload length is ONLY the bytes that are sent inside of the Data protobuf (excluding protobuf overhead). The 16 byte header is
 # outside of this envelope
-*Data.payload max_size:237
+*Data.payload max_size:233
 *Data.bitfield int_size:8
 
 *NodeInfo.channel int_size:8
@@ -62,7 +62,7 @@
 # or fixed_length or fixed_count, or max_count
 
 #This value may want to be a few bytes smaller to compensate for the parent fields.
-*Compressed.data max_size:237
+*Compressed.data max_size:233
 
 *Waypoint.name         max_size:30
 *Waypoint.description  max_size:100

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1268,7 +1268,7 @@ enum Constants {
    * note: this payload length is ONLY the bytes that are sent inside of the Data protobuf (excluding protobuf overhead). The 16 byte header is
    * outside of this envelope
    */
-  DATA_PAYLOAD_LEN = 237;
+  DATA_PAYLOAD_LEN = 233;
 }
 
 /*

--- a/meshtastic/storeforward.options
+++ b/meshtastic/storeforward.options
@@ -1,1 +1,1 @@
-*StoreAndForward.text max_size:237
+*StoreAndForward.text max_size:233


### PR DESCRIPTION
Updates `DATA_PAYLOAD_LEN` and .option fields to 233 bytes to reflect the new `Data` length limit due to added fields.