### PR TITLE
Add ignore_direct radio option

### DIFF
--- a/meshtastic/config.options
+++ b/meshtastic/config.options
@@ -8,6 +8,7 @@
 
 # Max of three ignored nodes for our testing
 *LoRaConfig.ignore_incoming max_count:3
+*LoRaConfig.ignore_direct max_size:3
 
 *LoRaConfig.tx_power int_size:8
 *LoRaConfig.bandwidth int_size:16

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -1006,6 +1006,14 @@ message Config {
      * Sets the ok_to_mqtt bit on outgoing packets
      */
     bool config_ok_to_mqtt = 105;
+
+    /*
+     * For testing this simulate a node which cannot be heared directly.
+     * All comunications received from this node will be dropped.
+     * Due to space constraints in the header, only the last byte of
+     * the relayer is transmited, thus only the last byte can be checked.
+     */
+    bytes ignore_direct = 106;
   }
 
   message BluetoothConfig {


### PR DESCRIPTION
# What does this PR do?

This allows to support a new option which I am using to test meshing when nodes are meters apart.

## Checklist before merging

- [X] All top level messages commented
- [X] All enum members have unique descriptions
