### PR TITLE
Add the ROUTER_LATE role & supporting fields

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -99,6 +99,15 @@ message Config {
        *    Uses position module configuration to determine TAK PLI broadcast interval.
        */
       TAK_TRACKER = 10;
+
+      /*
+       * Description: Will always rebroadcast packets, but will do so after all other modes.
+       * Technical Details: Used for router nodes that are intended to provide additional coverage
+       *    in areas not already covered by other routers, or to bridge around problematic terrain,
+       *    but should not be given priority over other routers in order to avoid unnecessaraily
+       *    consuming hops.
+       */
+      ROUTER_LATE = 11;
     }
 
     /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1272,6 +1272,13 @@ message MeshPacket {
    * Set by the firmware internally, clients are not supposed to set this.
    */
   uint32 relay_node = 19;
+
+  /*
+   * *Never* sent over the radio links.
+   * Timestamp after which this packet may be sent.
+   * Set by the firmware internally, clients are not supposed to set this.
+   */
+  uint32 tx_after = 20;
 }
 
 /*


### PR DESCRIPTION
This PR adds the new ~`ROUTER_INFILL`~ `ROUTER_LATE` role & supporting fields for the following firmware PR:

https://github.com/meshtastic/firmware/pull/5528