### PR TITLE
Add device_battery_num_cells

### DIFF
--- a/meshtastic/config.options
+++ b/meshtastic/config.options
@@ -15,6 +15,7 @@
 *LoRaConfig.channel_num int_size:16
 
 *PowerConfig.device_battery_ina_address int_size:8
+*PowerConfig.device_battery_num_cells int_size:8
 
 *SecurityConfig.public_key max_size:32
 *SecurityConfig.private_key max_size:32

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -431,6 +431,11 @@ message Config {
     uint32 device_battery_ina_address = 9;
 
     /*
+     * Number of battery cells in use. Battery charge is calculated using (v / num_cells).
+     */
+    uint32 device_battery_num_cells = 10;
+
+    /*
      * If non-zero, we want powermon log outputs.  With the particular (bitfield) sources enabled.
      * Note: we picked an ID of 32 so that lower more efficient IDs can be used for more frequently used options.
      */


### PR DESCRIPTION
Currently in firmware we hard-code NUM_CELLS (usually to 1), and our code for calculating battery charge uses this variable in ways like "voltage = v / NUM_CELLS;"

If the battery voltage is one cell around our 4V normal, that works fine. 

However, as reported in https://github.com/meshtastic/firmware/issues/5360 it's not uncommon for solar installs that have multiple batteries set up in a way that looks like 1 cell at 12V to our current code. So, battery charge % is always 100%.

Allowing num_cells as a configuration option will allow those users to specify how many batteries they have and receive accurate readings.