### PR TITLE
Move max sizes to powers of two

### DIFF
--- a/meshtastic/admin.options
+++ b/meshtastic/admin.options
@@ -2,12 +2,12 @@
 
 *AdminMessage.session_passkey max_size:8
 
-*AdminMessage.set_canned_message_module_messages max_size:201
-*AdminMessage.get_canned_message_module_messages_response max_size:201
-*AdminMessage.delete_file_request max_size:201
+*AdminMessage.set_canned_message_module_messages max_size:256
+*AdminMessage.get_canned_message_module_messages_response max_size:256
+*AdminMessage.delete_file_request max_size:256
 
-*AdminMessage.set_ringtone_message max_size:231
-*AdminMessage.get_ringtone_response max_size:231
+*AdminMessage.set_ringtone_message max_size:256
+*AdminMessage.get_ringtone_response max_size:256
 
 *HamParameters.call_sign max_size:8
 *HamParameters.short_name max_size:5

--- a/meshtastic/atak.options
+++ b/meshtastic/atak.options
@@ -1,8 +1,8 @@
-*Contact.callsign max_size:120
-*Contact.device_callsign max_size:120
+*Contact.callsign max_size:128
+*Contact.device_callsign max_size:128
 *Status.battery int_size:8
 *PLI.course int_size:16
-*GeoChat.message max_size:200
-*GeoChat.to max_size:120
-*GeoChat.to_callsign max_size:120
-*TAKPacket.detail max_size:220
+*GeoChat.message max_size:256
+*GeoChat.to max_size:128
+*GeoChat.to_callsign max_size:128
+*TAKPacket.detail max_size:256

--- a/meshtastic/cannedmessages.options
+++ b/meshtastic/cannedmessages.options
@@ -1,1 +1,1 @@
-*CannedMessageModuleConfig.messages max_size:201
+*CannedMessageModuleConfig.messages max_size:256

--- a/meshtastic/channel.options
+++ b/meshtastic/channel.options
@@ -2,4 +2,4 @@
 
 # 256 bit or 128 bit psk key
 *ChannelSettings.psk max_size:32
-*ChannelSettings.name max_size:12
+*ChannelSettings.name max_size:16

--- a/meshtastic/clientonly.options
+++ b/meshtastic/clientonly.options
@@ -1,4 +1,4 @@
-*DeviceProfile.long_name max_size:40
+*DeviceProfile.long_name max_size:64
 *DeviceProfile.short_name max_size:5
-*DeviceProfile.ringtone max_size:231
-*DeviceProfile.canned_messages max_size:201
+*DeviceProfile.ringtone max_size:256
+*DeviceProfile.canned_messages max_size:256

--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -5,7 +5,8 @@
 *id max_size:16 # node id strings
 *public_key max_size:32 # public key
 
-*User.long_name max_size:40
+*User.long_name max_size:64
+# This should be 4 but as a fixed size rather then 5 as a max with final null
 *User.short_name max_size:5
 
 *RouteDiscovery.route max_count:8
@@ -17,16 +18,16 @@
 
 # note: this payload length is ONLY the bytes that are sent inside of the Data protobuf (excluding protobuf overhead). The 16 byte header is
 # outside of this envelope
-*Data.payload max_size:233
+*Data.payload max_size:256
 *Data.bitfield int_size:8
 
 *NodeInfo.channel int_size:8
 *NodeInfo.hops_away int_size:8
 
 # Big enough for 1.2.28.568032c-d
-*MyNodeInfo.firmware_version max_size:18
+*MyNodeInfo.firmware_version max_size:32
 *MyNodeInfo.device_id max_size:16
-*MyNodeInfo.pio_env max_size:40
+*MyNodeInfo.pio_env max_size:64
 
 *MyNodeInfo.air_period_tx       max_count:8
 *MyNodeInfo.air_period_rx       max_count:8
@@ -51,30 +52,30 @@
 
 *Routing.variant anonymous_oneof:true
 
-*LogRecord.message max_size:384
+*LogRecord.message max_size:512
 *LogRecord.source max_size:32
 
-*FileInfo.file_name max_size:228
+*FileInfo.file_name max_size:256
 
-*ClientNotification.message max_size:400
+*ClientNotification.message max_size:512
 
 # MyMessage.name         max_size:40 
 # or fixed_length or fixed_count, or max_count
 
 #This value may want to be a few bytes smaller to compensate for the parent fields.
-*Compressed.data max_size:233
+*Compressed.data max_size:256
 
-*Waypoint.name         max_size:30
-*Waypoint.description  max_size:100
+*Waypoint.name         max_size:32
+*Waypoint.description  max_size:128
 
-*NeighborInfo.neighbors max_count:10
+*NeighborInfo.neighbors max_count:16
 
-*DeviceMetadata.firmware_version max_size:18
+*DeviceMetadata.firmware_version max_size:32
 
-*MqttClientProxyMessage.topic max_size:60
-*MqttClientProxyMessage.data max_size:435
-*MqttClientProxyMessage.text max_size:435
+*MqttClientProxyMessage.topic max_size:128
+*MqttClientProxyMessage.data max_size:512
+*MqttClientProxyMessage.text max_size:512
 
 *ChunkedPayload.chunk_count int_size:16
 *ChunkedPayload.chunk_index int_size:16
-*ChunkedPayload.payload_chunk max_size:228
+*ChunkedPayload.payload_chunk max_size:256

--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -16,7 +16,7 @@
 *ExternalNotificationConfig.nag_timeout int_size:16
 
 *RemoteHardwareConfig.available_pins max_count:4
-*RemoteHardwarePin.name max_size:15
+*RemoteHardwarePin.name max_size:16
 *RemoteHardwarePin.gpio_pin int_size:8
 
 *AmbientLightingConfig.current int_size:8
@@ -25,5 +25,5 @@
 *AmbientLightingConfig.blue int_size:8
 
 *DetectionSensorConfig.monitor_pin int_size:8
-*DetectionSensorConfig.name max_size:20
+*DetectionSensorConfig.name max_size:32
 *DetectionSensorConfig.detection_trigger_type max_size:8

--- a/meshtastic/mqtt.options
+++ b/meshtastic/mqtt.options
@@ -2,7 +2,7 @@
 *ServiceEnvelope.channel_id type:FT_POINTER
 *ServiceEnvelope.gateway_id type:FT_POINTER
 
-*MapReport.long_name max_size:40
+*MapReport.long_name max_size:64
 *MapReport.short_name max_size:5
-*MapReport.firmware_version max_size:18
+*MapReport.firmware_version max_size:32
 *MapReport.num_online_local_nodes int_size:16

--- a/meshtastic/rtttl.options
+++ b/meshtastic/rtttl.options
@@ -1,1 +1,1 @@
-*RTTTLConfig.ringtone max_size:231
+*RTTTLConfig.ringtone max_size:256

--- a/meshtastic/storeforward.options
+++ b/meshtastic/storeforward.options
@@ -1,1 +1,1 @@
-*StoreAndForward.text max_size:233
+*StoreAndForward.text max_size:256


### PR DESCRIPTION
Magic numbers like `233` with only the nanopb being constrainted is strange.  This imposes a theoredical limit to what should be a `bytes` in the PB definition.  We should not use magic numbers, but instead use powers of two where artifical limits are imposed, and should target to have these limits be large as feesible for the firmware since its chopping messages.

<!-- Describe what you are intending to change -->

# What does this PR do?

<!-- Please remove or replace the issue url -->

> [Related Issue](https://github.com/meshtastic/protobufs/issues/0)

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
