### PR TITLE
Added definition for MeshLink board

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -670,6 +670,11 @@ enum HardwareModel {
    */
   MESH_TAB = 86;
 
+  /*
+   * MeshLink board developed by LoraItalia. NRF52840, eByte E22900M22S (Will also come with other frequencies), 25w MPPT solar charger (5v,12v,18v selectable), support for gps, buzzer, oled or e-ink display, 10 gpios, hardware watchdog
+   * https://www.loraitalia.it
+   */
+  MESHLINK = 87;
   
 
   /*


### PR DESCRIPTION
Just added the definition for the new MeshLink board, as discussed here: https://github.com/meshtastic/firmware/pull/5736#discussion_r1903236576
