### PR TITLE
Mqtt shrink

### DIFF
--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -2,7 +2,7 @@
 
 *MQTTConfig.address max_size:64
 *MQTTConfig.username max_size:64
-*MQTTConfig.password max_size:64
+*MQTTConfig.password max_size:32
 *MQTTConfig.root max_size:32
 
 *AudioConfig.ptt_pin int_size:8

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -603,7 +603,7 @@ message ModuleConfig {
   }
 
   /*
-   * TODO: REPLACE
+   * Canned Messages Module Config
    */
   message CannedMessageConfig {
     /*


### PR DESCRIPTION
MQTT config is currently bigger than the LoRA MTU. Needs to shrink