### PR TITLE
telemetry: add dps310

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -557,6 +557,10 @@ enum TelemetrySensorType {
    */
   DFROBOT_RAIN = 35;
 
+  /*
+   * Infineon DPS310 High accuracy pressure and temperature
+   */
+  DPS310 = 36;
 }
 
 /*


### PR DESCRIPTION
# What does this PR do?

Adds an enum value for the [DPS310](https://www.infineon.com/dgdl/Infineon-DPS310-DataSheet-v01_02-EN.pdf?fileId=5546d462576f34750157750826c42242) 24-bit pressure sensor.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
