### PR TITLE
Add new Portnum 76 for Reticulum Network Stack Tunnel App

### DIFF
--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -207,6 +207,12 @@ enum PortNum {
   POWERSTRESS_APP = 74;
 
   /*
+   * Reticulum Network Stack Tunnel App
+   * ENCODING: Fragmented RNS Packet. Handled by Meshtastic RNS interface
+   */
+  RETICULUM_TUNNEL_APP = 76;
+
+  /*
    * Private applications should use portnums >= 256.
    * To simplify initial development and testing you can use "PRIVATE_APP"
    * in your code without needing to rebuild protobuf files (via [regen-protos.sh](https://github.com/meshtastic/firmware/blob/master/bin/regen-protos.sh))


### PR DESCRIPTION
Add a port number reservation for Reticulum tunneling over meshtastic. The new portnum is intended to reduce chance of interference with other private apps.

# What does this PR do?

Reticulum is a network stack/protocol which allows users to create low bandwidth networks over a variety of interface types. These features include, messaging, remote terminal execution, file transfers, audio messages, audio calls, etc and using the python library, these features can be used to create new network applications such as [meshchat](https://github.com/liamcottle/reticulum-meshchat). 

Since Meshtastic doesn't support these features, and RNode (reticulum firmware), isn't as versatile as Meshtastic firmware, bridging RNS over Meshtastic becomes desirable.  

[RNS_Over_Meshtastic](https://github.com/landandair/RNS_Over_Meshtastic) aims to bridge this gap providing a custom interface which can be added to Reticulum allowing it to make use of (relatively)higher speed(medium fast and above) networks. This means you can use any Reticulum app over a suitably fast Meshtastic network.

Thanks,