### PR TITLE
Add RAK12035VB Soil Moisture Sensor

### DIFF
--- a/meshtastic/telemetry.options
+++ b/meshtastic/telemetry.options
@@ -3,6 +3,7 @@
 
 *EnvironmentMetrics.iaq int_size:16
 *EnvironmentMetrics.wind_direction int_size:16
+*EnvironmentMetrics.soil_moisture int_size:8
 
 *LocalStats.num_online_nodes int_size:16
 *LocalStats.num_total_nodes int_size:16

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -143,7 +143,16 @@ message EnvironmentMetrics {
   * Rainfall in the last 24 hours in mm
   */
   optional float rainfall_24h = 20;
-
+  
+ /*
+   * Soil moisture measured (% 1-100)
+   */
+  optional uint32 soil_moisture = 21;
+  
+  /*
+   * Soil temperature measured (*C)
+   */
+  optional float soil_temperature = 22;
 }
 
 /*
@@ -565,7 +574,7 @@ enum TelemetrySensorType {
   /*
    * RAKWireless RAK12035 Soil Moisture Sensor Module
    */
-  DPS310 = 37;
+  RAK12035 = 37;
 }
 
 /*

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -561,6 +561,11 @@ enum TelemetrySensorType {
    * Infineon DPS310 High accuracy pressure and temperature
    */
   DPS310 = 36;
+  
+  /*
+   * RAKWireless RAK12035 Soil Moisture Sensor Module
+   */
+  DPS310 = 37;
 }
 
 /*


### PR DESCRIPTION
As per @Justin-Mann , the RAK12035 is a Soil Moisture Sensor made by RAKWireless. Up to three can be connected using the wisblock architecture.

Co-Authored-By: @Justin-Mann