### PR TITLE
Fix empty doc to satisfy picky linters

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -74,7 +74,7 @@ message AdminMessage {
     SECURITY_CONFIG = 7;
 
     /*
-     *
+     * Session key config
      */
     SESSIONKEY_CONFIG = 8;
 


### PR DESCRIPTION
Our Rust clippy linter hit this error when we've updated to fresh protobufs:
```
$ cargo clippy -- -D warnings
error: empty doc comment
    --> src/generated/meshtastic.rs:6366:9
     |
6366 | /         ///
6367 | |         ///
     | |___________^
     |
     = help: consider removing or filling it
```

