### PR TITLE
Adding GoLang output path to nanopb.proto

### DIFF
--- a/nanopb.proto
+++ b/nanopb.proto
@@ -10,6 +10,7 @@ syntax = "proto2";
 import "google/protobuf/descriptor.proto";
 
 option java_package = "fi.kapsi.koti.jpa.nanopb";
+option go_package = "github.com/meshtastic/go/generated";
 
 enum FieldType {
   FT_DEFAULT = 0; // Automatically decide field type, generate static field if possible.


### PR DESCRIPTION
<!-- Describe what you are intending to change -->
This makes building the protobufs for golang easier

# What does this PR do?
Add the golang protobuf output path to the nanopb.proto, the same as already in the rest of the protos.

<!-- Please remove or replace the issue url -->

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
