### PR TITLE
Add go_package path for nanopb.proto

### DIFF
--- a/nanopb.proto
+++ b/nanopb.proto
@@ -9,6 +9,7 @@ syntax = "proto2";
 
 import "google/protobuf/descriptor.proto";
 
+option go_package = "github.com/meshtastic/go/generated";
 option java_package = "fi.kapsi.koti.jpa.nanopb";
 
 enum FieldType {


### PR DESCRIPTION
<!-- Describe what you are intending to change -->
Adds the go_package output path to nanopb.proto to match the other .proto files and fix protobuf build errors.

# What does this PR do?
Adds the go_package output path to nanopb.proto to match the other .proto files and fix protobuf build errors.

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
