### PR TITLE
Fix comment description of CO2 telemetry value

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -255,7 +255,7 @@ message AirQualityMetrics {
   optional uint32 particles_100um = 12;
 
   /*
-   * 10.0um Particle Count
+   * CO2 concentration in ppm
    */
   optional uint32 co2 = 13;
 }


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?

Fixes a comment describing the CO2 value. Looks like copy and paste error, where the update of the description was forgotten.

