### PR TITLE
Update mesh.proto

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -708,6 +708,7 @@ enum HardwareModel {
    * Heltec Magnetic Power Bank with Meshtastic compatible
    */
   HELTEC_MESH_POCKET = 94;
+  
   /*
    * RAK_killer Breakout PCB - Promicro nRF52840 and Heltec HT-RA62
    */

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -708,6 +708,10 @@ enum HardwareModel {
    * Heltec Magnetic Power Bank with Meshtastic compatible
    */
   HELTEC_MESH_POCKET = 94;
+  /*
+   * RAK_killer Breakout PCB - Promicro nRF52840 and Heltec HT-RA62
+   */
+  RAK_KILLER = 95;
 
   /*
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/Uroboros67/rak_killer

Breakout PCB for Supermini/Promicro NRF52840 tile with HELTEC HT-RA62 Lora module (and I2C and voltage measurement) with PCB fields for two SMD 1206 resistors and pins system directly under I2C, such as ina219.

<!-- Describe what you are intending to change -->

# What does this PR do?

<!-- Please remove or replace the issue url -->

> [Related Issue](https://github.com/meshtastic/protobufs/issues/0)

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
