### PR TITLE
Add MAX17261 lipo battery gauge

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -575,6 +575,11 @@ enum TelemetrySensorType {
    * RAKWireless RAK12035 Soil Moisture Sensor Module
    */
   RAK12035 = 37;
+
+  /*
+   * MAX17261 lipo battery gauge
+   */
+  MAX17261 = 38;
 }
 
 /*


### PR DESCRIPTION
Add [MAX17261](https://www.analog.com/media/en/technical-documentation/data-sheets/max17261.pdf) lipo battery gauge

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
