### PR TITLE
Add the user_string to HostMetrics

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -383,6 +383,12 @@ message HostMetrics {
    * Host system fifteen minute load  in 1/100ths
    */
   uint32 load15 = 8;
+
+  /*
+   * Optional User-provided string for arbitrary host system information
+   * that doesn't make sense as a dedicated entry.
+   */
+  optional string user_string = 9;
 }
 
 


### PR DESCRIPTION
We can't predict what information a user might want to send with the HostMetrics message, so provide an optional arbitrary string for the purpose.