### PR TITLE
Add PCT2075 sensor

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -631,6 +631,11 @@ enum TelemetrySensorType {
    * MAX17261 lipo battery gauge
    */
   MAX17261 = 38;
+
+  /*
+   * PCT2075 Temperature Sensor
+   */
+  PCT2075 = 39;
 }
 
 /*


### PR DESCRIPTION
# What does this PR do?

This PR adds a definition for the PCT2075 temperature sensor

This relates to https://github.com/meshtastic/firmware/pull/6829