### PR TITLE
Add GAT562 Mesh Trial Tracker HW model ID

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -754,6 +754,11 @@ enum HardwareModel {
    */
   T_LORA_PAGER = 103;
 
+  /**
+   * GAT562 Mesh Trial Tracker
+   */
+  GAT562_MESH_TRIAL_TRACKER = 104;
+
   /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.


### PR DESCRIPTION
# What does this PR do?

Add GAT562 Mesh Trial Tracker HW model ID


> [Related Issue](https://github.com/meshtastic/firmware/pull/6984)

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
