### PR TITLE
Add ANZ_433 Region

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -911,6 +911,11 @@ message Config {
        * Philippines 915mhz
        */
       PH_915 = 21;
+      /*
+       * Australia / New Zealand 433MHz
+       */
+      ANZ_433 = 22;
+
     }
 
     /*


### PR DESCRIPTION
As reported by @monkeypants, the MY_433 region is not legal in ANZ due to power limits being too high. This patch introduced an ANZ_433 region to match the requirements in Australia and New Zealand.

433.05 - 434.79 MHz, 25mW EIRP max, No duty cycle restrictions AU Low Interference Potential https://www.acma.gov.au/licences/low-interference-potential-devices-lipd-class-licence NZ General User Radio Licence for Short Range Devices https://gazette.govt.nz/notice/id/2022-go3100

Fixes https://github.com/meshtastic/firmware/issues/7032