### PR TITLE
Update mesh.proto to add support for board EoRa HUB X00TB LR1121

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -759,6 +759,11 @@ enum HardwareModel {
    */
   GAT562_MESH_TRIAL_TRACKER = 104;
 
+  /**
+   * EoRa HUB X00TB LR1121 (433MHz/868MHz-915MHz & 2.4GHz)
+   */
+  EoRa-HUB-X00TB = 105;
+
   /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.


### PR DESCRIPTION
Add support for EoRa HUB X00TB LR1121

Support for the Board [EoRa HUB X00TB LR1121](https://www.cdebyte.com/products/EoRa-HUB-900TB/7?_gl=1*nuoi6z*_up*MQ..*_ga*MTQyNzAyODI3Mi4xNzUwMjMyNzE5*_ga_87PTK0Y2S4*czE3NTAyMzI3MTkkbzEkZzAkdDE3NTAyMzI3MTkkajYwJGwwJGgw*_ga_YQYYBFPDGW*czE3NTAyMzI3MTkkbzEkZzAkdDE3NTAyMzI3MTkkajYwJGwwJGgxNjQ1Mzk5NTQ5#Series) on the way! The only thing that is missing is the voltage reader, but as a personal node works just fine. Battery can be recharged via USB C just fine, but no voltage can be shown. Everything else works. Have been using it for a few weeks as personal device and runs perfectly fine :).

# What does this PR do?

Add a new Enum for the board, so it can be used on the Hardware Enum list while building.
> [Related Issue](https://github.com/meshtastic/firmware/issues/6978)

## Checklist before merging

- [X] All top level messages commented
- [X] All enum members have unique descriptions
