### PR TITLE
Add PortNum for Cayenne Low Power Payload

### DIFF
--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -218,6 +218,13 @@ enum PortNum {
   RETICULUM_TUNNEL_APP = 76;
 
   /*
+   * App for transporting Cayenne Low Power Payload, popular for LoRaWAN sensor nodes. Offers ability to send
+   * arbitrary telemetry over meshtastic that is not covered by telemetry.proto
+   * ENCODING: CayenneLLP
+   */
+  CAYENNE_APP = 77;
+
+  /*
    * Private applications should use portnums >= 256.
    * To simplify initial development and testing you can use "PRIVATE_APP"
    * in your code without needing to rebuild protobuf files (via [regen-protos.sh](https://github.com/meshtastic/firmware/blob/master/bin/regen-protos.sh))


### PR DESCRIPTION
Add support for Cayenne Low Power Payload popular in LoRaWAN. This has benefit of removing burden to specify every conceivable telemetry type in telemetry.proto while still relying on well defined telemetry/data types from Open Mobile Alliance (OMA) / IPSO Alliance (or fully custom ones according to IPSO alliance numbering scheme)

Also enables very constrained sensor nodes that are not capable of building bigger / nested protobuf structures (in contrast to protobuf in protobuf encoding like telemetry.proto / telemetry app)

Some references: 
- https://docs.mydevices.com/docs/lorawan/cayenne-lpp
- https://www.thethingsindustries.com/docs/integrations/payload-formatters/cayenne/
- https://www.openmobilealliance.org/specifications/registries/objects


