### PR TITLE
Add ADS1X15 voltage metrics

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -188,6 +188,11 @@ message PowerMetrics {
    * Current (Ch3)
    */
   optional float ch3_current = 6;
+
+  /*
+   * Voltage (Ch4)
+   */
+  optional float ch4_voltage = 7;
 }
 
 /*
@@ -652,6 +657,11 @@ enum TelemetrySensorType {
    * PCT2075 Temperature Sensor
    */
   PCT2075 = 39;
+
+  /*
+   * ADS1X15 ADC
+   */
+  ADS1X15 = 40;
 }
 
 /*


### PR DESCRIPTION
[ADS1X15 ADCs](https://cdn-shop.adafruit.com/datasheets/ads1115.pdf) are 4-channel I2C ADCs with configurable I2C Addresses. This PR adds the SensorType and created an additional channel for it in the PowerMetrics` protobuf.

# What does this PR do?

This PR adds the `TelemetrySensorType` and creates an additional channel for it in the `PowerMetrics` protobuf.
This, is however incomplete: the problem being that up to 4x ADS1X15s can be chained together, and each one of them with 4 channels, making up for a total of 16 channels.

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
