### PR TITLE
Add RAKwireless hardware models 1.RAK3112  2.Wismeshtag

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -759,6 +759,16 @@ enum HardwareModel {
    */
   GAT562_MESH_TRIAL_TRACKER = 104;
 
+  /**
+  * RAKwireless WisMesh Tag 
+  */
+  WISMESH_TAG = 105;
+
+  /**
+  * RAKwireless RAK3112 https://docs.rakwireless.com/product-categories/wisduo/rak3112-module/overview/
+  */
+  RAK3112 = 106;
+
   /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.


### PR DESCRIPTION
This pull request adds new hardware models to the `HardwareModel` enum in the `meshtastic/mesh.proto` file. These changes expand the supported device types for the Mesh network.

New hardware models added:

* [`WISMESH_TAG`](diffhunk://#diff-55a2a13f14ada19c3bc298a7dab001d67b7f5896c3dd68c9542e7563bedcf663R762-R771): Represents the RAKwireless WisMesh Tag.
![image](https://github.com/user-attachments/assets/e4a2559b-d19f-45f4-8093-fe5e013adcb5)


* [`RAK3112`](diffhunk://#diff-55a2a13f14ada19c3bc298a7dab001d67b7f5896c3dd68c9542e7563bedcf663R762-R771): Represents the RAKwireless RAK3112 module, with documentation linked for reference.[Copilot is generating a summary...]
https://docs.rakwireless.com/product-categories/wisduo/rak3112-module/overview/
![image](https://github.com/user-attachments/assets/7efc7109-bcf2-4b93-9372-3ad3cc2195d4)


