### PR TITLE
Add additional telemetry sensor type to support two ADS1X15s

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -716,6 +716,11 @@ enum TelemetrySensorType {
    * ADS1X15 ADC
    */
   ADS1X15 = 40;
+
+  /*
+   * ADS1X15 ADC_ALT
+   */
+  ADS1X15_ALT = 41;
 }
 
 /*


### PR DESCRIPTION
An additional sensor type to be able to support two ADS1X15 sensors in parallel. Goes with https://github.com/meshtastic/firmware/pull/7109
