### PR TITLE
Add Kazakhstan frequencies

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -915,6 +915,14 @@ message Config {
        * Australia / New Zealand 433MHz
        */
       ANZ_433 = 22;
+      /*
+       * Kazakhstan 433MHz
+       */
+      KZ_433 = 23;
+      /*
+       * Kazakhstan 863MHz
+       */
+      KZ_863 = 24;
 
     }
 


### PR DESCRIPTION
As reported by @KZ1R , Kazakhstan has frequencies in use for Lora devices that are not covered by our existing band selections.

This adds
* KZ_433 433.075 - 434.775 MHz <10 mW EIRP, Low Powered Devices (LPD)
* KZ_863 863 - 868 MHz <25 mW EIRP, 500kHz channels allowed, must not be used at airfields

Legal ref provided in https://github.com/meshtastic/firmware/issues/7204 and verified.

https://www.gov.kz/memleket/entities/mdai/press/article/details/6128 Order of the Ministry of Investments and Development of the Republic of Kazakhstan No. 34 dated January 21, 2015.
 Published on 01 July 2024 19:03 Updated on 01 July 2024

Fixes https://github.com/meshtastic/firmware/issues/7204