### PR TITLE
feat(display): enable screen wake on received messages

### DIFF
--- a/meshtastic/device_ui.proto
+++ b/meshtastic/device_ui.proto
@@ -88,6 +88,12 @@ message DeviceUIConfig {
    * true for analog clockface, false for digital clockface
    */
   bool is_clockface_analog = 18;
+
+  /*
+   * If true (default), the screen will automatically turn on when a message is received.
+   * If false, the screen will only turn on via button press or other manual input.
+   */
+  bool wake_on_received_message = 19;
 }
 
 


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?

Bring the feature on Enable or disable wake up screen when message received.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions


### New Hardware Model Acceptance Policy

Due to limited availability and ongoing support, new Hardware Models will only be accepted from [Meshtastic Backers and Partners](https://meshtastic.com/). The Meshtastic team reserves the right to make exceptions to this policy.

#### Alternative for Community Contributors

You are welcome to use one of the existing DIY hardware models in your PlatformIO environment and create a pull request in the firmware project. Please note the following conditions:

- The device will **not** be officially supported by the core Meshtastic team.
- The device will **not** appear in the [Web Flasher](https://flasher.meshtastic.org/) or Github release assets.
- You will be responsible for ongoing maintenance and support.
- Community-contributed / DIY hardware models are considered experimental and will likely have limited or no testing.

#### Getting Official Support

To have your hardware model officially supported and included in the Meshtastic ecosystem, consider becoming a Meshtastic Backer or Partner. Visit [meshtastic.com](https://meshtastic.com/) for more information about partnership opportunities.
