### PR TITLE
Add DIRECT_MSG_ONLY Buzzer mode

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -178,6 +178,13 @@ message Config {
        * Buzzer is enabled only for non-notification tones such as button presses, startup, shutdown, but not for alerts.
        */
       SYSTEM_ONLY = 3;
+
+      /*
+       * Direct Message notifications only.
+       * Buzzer is enabled only for direct messages and alerts, but not for button presses.
+       * External notification config determines the specifics of the notification behavior.
+       */
+      DIRECT_MSG_ONLY = 4;
     }
 
     /*


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?

Add `DIRECT_MSG_ONLY` option for BuzzerMode.
Allow the user to set external notifications to only buzz upon Direct Messages.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
