### PR TITLE
Add event_mode options to LocalConfig

### DIFF
--- a/meshtastic/localonly.options
+++ b/meshtastic/localonly.options
@@ -1,0 +1,1 @@
+*LocalConfig.event_mode_title max_size:33

--- a/meshtastic/localonly.proto
+++ b/meshtastic/localonly.proto
@@ -63,6 +63,18 @@ message LocalConfig {
    * The part of the config that is specific to Security settings
    */
   Config.SecurityConfig security = 9;
+
+  /*
+   * Set when the firmware has been compiled with event mode support
+   */
+  bool event_mode_enabled = 10;
+
+  /*
+   * Title for event mode firmware
+   * Ex: "burningmesh2025"
+   * Set at compile time, consumed by clients to modify UI behavior
+   */
+  string event_mode_title = 11;
 }
 
 message LocalModuleConfig {


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?

Add `event_mode_enabled` and `event_mode_title` to LocalConfig proto.

This should facilitate the firmware conveying "I am in event_mode, `burningmesh2025`" to clients, which can choose to behave differently (example, load custom Burning Man KML in App when using the event firmware)

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions