### PR TITLE
Added formaldehyde sensor values sfa30

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -323,10 +323,12 @@ message AirQualityMetrics {
    * Formaldehyde sensor formaldehyde concentration in ppb
    */
   optional float form_formaldehyde = 16;
+
   /*
    * Formaldehyde sensor relative humidity in %RH
    */
   optional float form_humidity = 17;
+
   /*
    * Formaldehyde sensor temperature in degrees Celsius
    */

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -318,6 +318,19 @@ message AirQualityMetrics {
    * CO2 sensor relative humidity in %
    */
   optional float co2_humidity = 15;
+
+  /*
+   * Formaldehyde sensor formaldehyde concentration in ppb
+   */
+  optional float form_formaldehyde = 16;
+  /*
+   * Formaldehyde sensor relative humidity in %RH
+   */
+  optional float form_humidity = 17;
+  /*
+   * Formaldehyde sensor temperature in degrees Celsius
+   */
+  optional float form_temperature = 18;
 }
 
 /*
@@ -721,6 +734,11 @@ enum TelemetrySensorType {
    * ADS1X15 ADC_ALT
    */
   ADS1X15_ALT = 41;
+
+  /*
+   * Sensirion SFA30 Formaldehyde sensor
+   */
+  SFA30 = 42;
 }
 
 /*

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -716,6 +716,11 @@ enum TelemetrySensorType {
    * ADS1X15 ADC
    */
   ADS1X15 = 40;
+
+  /*
+   * ADS1X15 ADC_ALT
+   */
+  ADS1X15_ALT = 41;
 }
 
 /*


### PR DESCRIPTION
This PR adds SFA30 device and associated metrics to support data logging of [HCHO](https://en.wikipedia.org/wiki/Formaldehyde) with electrochemical sensors by Sensirion. Done by @Nikl174.