### PR TITLE
Add Nepal 865 MHz to 868 MHz

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -931,6 +931,10 @@ message Config {
        * Kazakhstan 863MHz
        */
       KZ_863 = 24;
+      /*
+       * Nepal 865MHz
+       */
+      NP_865 = 25;
     }
 
     /*


### PR DESCRIPTION
As identified by @WOD-MN , Nepal has a dedicated IoT frequency.

865 MHz to 868 MHz, no power limit, not duty cycle restrictions
Machine to Machine (M2M)/Internet of Things (IoT)  https://www.nta.gov.np/uploads/contents/Radio-Frequency-Policy-2080-English.pdf

Firmware patch: https://github.com/meshtastic/firmware/pull/7380