### PR TITLE
Add BR_902, Brazil 902MHz-907.5MHz

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -931,6 +931,10 @@ message Config {
        * Kazakhstan 863MHz
        */
       KZ_863 = 24;
+      /*
+       * Brazil 902MHz
+       */
+      BR_902 = 25;
     }
 
     /*


### PR DESCRIPTION
As reported by @barbabarros , the Brazilian government has specific support for LoRA[1] across multiple frequencies[2][3].

We currently support Brazil through the ANZ/AU915 band. However, Brazil also has another frequency available for use:

902 - 907.5 MHz , 1W power limit, no duty cycle restrictions


[1]  https://sistemas.anatel.gov.br/anexar-api/publico/anexos/download/a028ab5cc4e3f97442830bba0c8bd1dd [2] 
https://informacoes.anatel.gov.br/legislacao/resolucoes/2025/2001-resolucao-772 [3] https://informacoes.anatel.gov.br/legislacao/atos-de-certificacao-de-produtos/2017/1139-ato-14448#item10


Fixes https://github.com/meshtastic/firmware/issues/3741