### PR TITLE
Add event enum to indicate to client if this is event firmware

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -919,27 +919,27 @@ message Config {
        * Philippines 915mhz
        */
       PH_915 = 21;
-      
+
       /*
        * Australia / New Zealand 433MHz
        */
       ANZ_433 = 22;
-      
+
       /*
        * Kazakhstan 433MHz
        */
       KZ_433 = 23;
-      
+
       /*
        * Kazakhstan 863MHz
        */
       KZ_863 = 24;
-      
+
       /*
        * Nepal 865MHz
        */
       NP_865 = 25;
-      
+
       /*
        * Brazil 902MHz
        */

--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -31,6 +31,8 @@
 *MyNodeInfo.air_period_tx       max_count:8
 *MyNodeInfo.air_period_rx       max_count:8
 
+*MyNodeInfo.firmware_edition int_size:8
+
 # Note: the actual limit (because of header bytes) on the size of encrypted payloads is 251 bytes, but I use 256
 # here because we might need to fill with zeros for padding to encryption block size (16 bytes per block)
 *MeshPacket.encrypted max_size:256

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1662,8 +1662,6 @@ enum FirmwareEdition {
    */
   HAMVENTION = 19;
 
-
-
   /*
    * Placeholder for DIY and unofficial events
    */

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1628,33 +1628,46 @@ enum CriticalErrorCode {
 }
 
 /*
- * Enum to indicate to clients whether this firmware is an event firmware build.
+ * Enum to indicate to clients whether this firmware is a special firmware build, like an event.
+ * The first 16 values are reserved for non-event special firmwares, like the Smart Citizen use case.
  */
-enum EventFirmwareIndicator {
+enum FirmwareEdition {
   /*
    * Vanilla firmware
    */
   VANILLA = 0;
 
   /*
+   * Firmware for use in the Smart Citizen environmental monitoring network
+   */
+  SMART_CITIZEN = 1;
+
+  /*
    * Open Sauce, the maker conference held yearly in CA
    */
-  OPEN_SAUCE = 1;
+  OPEN_SAUCE = 16;
 
   /*
    * DEFCON, the yearly hacker conference
    */
-  DEFCON = 2;
+  DEFCON = 17;
 
   /*
    * Burning Man, the yearly hippie gathering in the desert
    */
-  BURNING_MAN = 3;
+  BURNING_MAN = 18;
 
   /*
    * Hamvention, the Dayton amateur radio convention
    */
-  HAMVENTION = 4;
+  HAMVENTION = 19;
+
+
+
+  /*
+   * Placeholder for DIY and unofficial events
+   */
+  DIY_EDITION = 127;
 }
 
 /*
@@ -1694,7 +1707,7 @@ message MyNodeInfo {
   /*
    * The indicator for whether this device is running event firmware and which
    */
-  EventFirmwareIndicator event_firmware = 14;
+  FirmwareEdition firmware_edition = 14;
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1639,12 +1639,12 @@ enum EventFirmwareIndicator {
   /*
    * Open Sauce, the maker conference held yearly in CA
    */
-   OPEN_SAUCE = 1;
+  OPEN_SAUCE = 1;
 
   /*
    * DEFCON, the yearly hacker conference
    */
-   DEFCON = 2;
+  DEFCON = 2;
 
   /*
    * Burning Man, the yearly hippie gathering in the desert

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1628,6 +1628,31 @@ enum CriticalErrorCode {
 }
 
 /*
+ * Enum to indicate to clients whether this firmware is an event firmware build.
+ */
+enum EventFirmwareIndicator {
+  /*
+   * Vanilla firmware
+   */
+  VANILLA = 0;
+
+  /*
+   * Open Sauce, the maker conference held yearly in CA
+   */
+   OPEN_SAUCE = 1;
+
+  /*
+   * DEFCON, the yearly hacker conference
+   */
+   DEFCON = 2;
+
+  /*
+   * Burning Man, the yearly hippie gathering in the desert
+   */
+  BURNING_MAN = 3;
+}
+
+/*
  * Unique local debugging info for this node
  * Note: we don't include position or the user info, because that will come in the
  * Sent to the phone in response to WantNodes.
@@ -1660,6 +1685,11 @@ message MyNodeInfo {
    * The PlatformIO environment used to build this firmware
    */
   string pio_env = 13;
+
+  /*
+   * The indicator for whether this device is running event firmware and which
+   */
+  EventFirmwareIndicator event_firmware = 14;
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1650,6 +1650,11 @@ enum EventFirmwareIndicator {
    * Burning Man, the yearly hippie gathering in the desert
    */
   BURNING_MAN = 3;
+
+  /*
+   * Hamvention, the Dayton amateur radio convention
+   */
+  HAMVENTION = 4;
 }
 
 /*

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -333,7 +333,7 @@ message AirQualityMetrics {
    * Formaldehyde sensor temperature in degrees Celsius
    */
   optional float form_temperature = 18;
-  
+
   /*
    * Concentration Units Standard PM4.0 in ug/m3
    */


### PR DESCRIPTION
It may be useful to the clients to know if the firmware they are connecting to is an event firmware. This gives us an easy place to indicate.