### PR TITLE
Add Viet Nam regions VN_433 & VN_923

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -944,6 +944,16 @@ message Config {
        * Brazil 902MHz
        */
       BR_902 = 26;
+
+      /*
+       * Viet Nam 433MHz
+       */
+      VN_433 = 27;
+
+      /*
+       * Viet Nam 923MHz
+       */
+      VN_923 = 28;
     }
 
     /*


### PR DESCRIPTION
Hijacking [protobufs #730](https://github.com/meshtastic/protobufs/pull/730) to add VN_433 and VN_923 for Viet Nam.

Will follow up with more information in firmware PR: [firmware #7458](https://github.com/meshtastic/firmware/pull/7458)