### PR TITLE
Add GPS Profile, deprecate Position Flags

### DIFF
--- a/meshtastic/config.options
+++ b/meshtastic/config.options
@@ -2,6 +2,7 @@
 *DeviceConfig.tzdef max_size:65
 *DeviceConfig.buzzer_mode int_size:8
 
+*PositionConfig.gps_profile int_size:8
 
 *NetworkConfig.wifi_ssid max_size:33
 *NetworkConfig.wifi_psk max_size:65

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -377,6 +377,11 @@ message Config {
        * Cars, motorbikes.
        */
       VEHICLE = 3;
+
+      /*
+       * Planes, balloons, drones.
+       */
+      AIRBORNE = 4;
     }
 
     /*

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -345,7 +345,7 @@ message Config {
        */
       NOT_PRESENT = 2;
     }
-    
+
     /*
      * A plain language label that users of GPS select based on their intended activity.
      * We use this to make selections from the variety of GPS Settings, including:
@@ -362,8 +362,8 @@ message Config {
       MANUAL = 0;
 
       /*
-       * This node does not move. 
-       * We automatically apply this to all routers, router_lates, 
+       * This node does not move.
+       * We automatically apply this to all routers, router_lates,
        * and any node with manually set lat/lon.
        */
       FIXED_POSITION = 1;
@@ -372,7 +372,7 @@ message Config {
        * Hikers, runners, walkers.
        */
       PEDESTRIAN = 2;
-      
+
       /*
        * Cars, motorbikes.
        */

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -266,66 +266,67 @@ message Config {
      * are always included (also time if GPS-synced)
      * NOTE: the more fields are included, the larger the message will be -
      *   leading to longer airtime and a higher risk of packet loss
+     * DEPRECATED in favor of GpsProfile
      */
     enum PositionFlags {
       /*
        * Required for compilation
        */
-      UNSET = 0x0000;
+      UNSET = 0x0000 [deprecated = true];
 
       /*
        * Include an altitude value (if available)
        */
-      ALTITUDE = 0x0001;
+      ALTITUDE = 0x0001 [deprecated = true];
 
       /*
        * Altitude value is MSL
        */
-      ALTITUDE_MSL = 0x0002;
+      ALTITUDE_MSL = 0x0002 [deprecated = true];
 
       /*
        * Include geoidal separation
        */
-      GEOIDAL_SEPARATION = 0x0004;
+      GEOIDAL_SEPARATION = 0x0004 [deprecated = true];
 
       /*
        * Include the DOP value ; PDOP used by default, see below
        */
-      DOP = 0x0008;
+      DOP = 0x0008 [deprecated = true];
 
       /*
        * If POS_DOP set, send separate HDOP / VDOP values instead of PDOP
        */
-      HVDOP = 0x0010;
+      HVDOP = 0x0010 [deprecated = true];
 
       /*
        * Include number of "satellites in view"
        */
-      SATINVIEW = 0x0020;
+      SATINVIEW = 0x0020 [deprecated = true];
 
       /*
        * Include a sequence number incremented per packet
        */
-      SEQ_NO = 0x0040;
+      SEQ_NO = 0x0040 [deprecated = true];
 
       /*
        * Include positional timestamp (from GPS solution)
        */
-      TIMESTAMP = 0x0080;
+      TIMESTAMP = 0x0080 [deprecated = true];
 
       /*
        * Include positional heading
        * Intended for use with vehicle not walking speeds
        * walking speeds are likely to be error prone like the compass
        */
-      HEADING = 0x0100;
+      HEADING = 0x0100 [deprecated = true];
 
       /*
        * Include positional speed
        * Intended for use with vehicle not walking speeds
        * walking speeds are likely to be error prone like the compass
        */
-      SPEED = 0x0200;
+      SPEED = 0x0200 [deprecated = true];
     }
 
     enum GpsMode {
@@ -343,6 +344,39 @@ message Config {
        * GPS is not present on the device
        */
       NOT_PRESENT = 2;
+    }
+    
+    /*
+     * A plain language label that users of GPS select based on their intended activity.
+     * We use this to make selections from the variety of GPS Settings, including:
+     * GPS Update Interval, Position Broadcast Interval, Smart Broadcast Min Interval,
+     * Smart Broadcast Min Distance, and Position Flags. The firmware also modifies the
+     * GPS hardware configuration to take advantage of advanced features for each case.
+     * The firmware may also discard erroneous positions based on movement determined to
+     * be physically impossible.
+     */
+    enum GpsProfile {
+      /*
+       * Profile not set, user will make their own decisions.
+       */
+      MANUAL = 0;
+
+      /*
+       * This node does not move. 
+       * We automatically apply this to all routers, router_lates, 
+       * and any node with manually set lat/lon.
+       */
+      FIXED_POSITION = 1;
+
+      /*
+       * Hikers, runners, walkers.
+       */
+      PEDESTRIAN = 2;
+      
+      /*
+       * Cars, motorbikes.
+       */
+      VEHICLE = 3;
     }
 
     /*
@@ -383,8 +417,9 @@ message Config {
     /*
      * Bit field of boolean configuration options for POSITION messages
      * (bitwise OR of PositionFlags)
+     * DEPRECATED in favour of GPS Profile
      */
-    uint32 position_flags = 7;
+    uint32 position_flags = 7 [deprecated = true];
 
     /*
      * (Re)define GPS_RX_PIN for your board.
@@ -415,6 +450,11 @@ message Config {
      * Set where GPS is enabled, disabled, or not present
      */
     GpsMode gps_mode = 13;
+
+    /*
+     * A pre-tuned mode of operation for the GPS based on use-case.
+     */
+    GpsProfile gps_profile = 14;
   }
 
   /*


### PR DESCRIPTION
This patch makes two major changes to address the current complexity of GPS Configuration.

## GPS Profile
GpsProfile, a new enum in PositionConfig we will use to configure a pre-tuned selection of GPS settings. The aim is to replace the current 5 configuration options with a single user-friendly label that is tailored to real-world Meshtastic use cases.

Based on a users selection of pedestrian, vehicle, or fixed position, we will apply different settings to GPS Update Interval, Position Broadcast Interval, Smart Broadcast Min Interval, Smart Broadcast Min Distance, and Position Flags in firmware. This should allow the apps to drastically simplify the position configuration shown to users.

The profile will also allow us to support new features in firmware to improve the accuracy of our position information. For example,  taking advantage of advanced features in GPS hardware specific to each case. We should also be able to discard some erroneous positions based on physically impossible movement.

ENUM 0 corresponds to no profile, which should mean an easier transition, and also support the 'manual' use case for people like cynfab/gpsfan, and balloons/aircraft/boats.

More information about the selections anticipated for each use case is available in this [google sheet](https://docs.google.com/spreadsheets/d/1-f9z5zx2VCYqE6ivYXm-XqtLeVZSGMKpC3G3wma6-vw/edit?gid=633840990#gid=633840990)


## PositionFlags
This patch deprecates PositionFlags, which will now be selected in firmware based on the GPS Profile.

PositionFlags has long been seen as a complicated and confusing burden in the apps. We determined that very few users use them, with the majority happy with the default set, and some of the 'advanced' flags don't even work.


## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions

