### PR TITLE
Add Isreal frequency config entry

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -944,6 +944,11 @@ message Config {
        * Brazil 902MHz
        */
       BR_902 = 26;
+
+      /*
+       * Israel 917MHz
+       */
+      IL_917 = 27;
     }
 
     /*


### PR DESCRIPTION
Israel region frequencies config

This adds **IL_917** - 917.3 - 919.9 MHz, <25 mW erp, 1% duty cycle, 200 kHz spacing, 125 kHz bandwidth

Legal info provided in [https://github.com/meshtastic/firmware/pull/7590](https://github.com/meshtastic/firmware/pull/7590)