### PR TITLE
Rangetest cleanup configuration option

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -530,6 +530,12 @@ message ModuleConfig {
      * ESP32 Only
      */
     bool save = 3;
+
+    /*
+     * Bool indicating that the node should cleanup / destroy it's RangeTest.csv file.
+     * ESP32 Only
+     */
+    bool clear = 4;
   }
 
   /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -535,7 +535,7 @@ message ModuleConfig {
      * Bool indicating that the node should cleanup / destroy it's RangeTest.csv file.
      * ESP32 Only
      */
-    bool clear = 4;
+    bool clear_on_reboot = 4;
   }
 
   /*


### PR DESCRIPTION
<!-- Describe what you are intending to change -->
Includes a configuration option which allow's the toggling of cleanup capabilities for RangeTest results.

<!-- Please remove or replace the issue url -->
See: [https://github.com/meshtastic/firmware/pull/7703](https://github.com/meshtastic/firmware/pull/7703)

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
