### PR TITLE
Add battery percentage to device metadata

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2213,6 +2213,11 @@ message DeviceMetadata {
    * (bitwise OR of ExcludedModules)
    */
   uint32 excluded_modules = 12;
+
+  /*
+   * Battery charge percentage
+   */
+   uint32 remaining_battery = 13;
 }
 
 /*


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?
This PR includes the device's current battery percentage in metadata responses.

<!-- Please remove or replace the issue url -->

> [Related Issue](https://github.com/meshtastic/firmware/pull/7795)

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
