### PR TITLE
Reserve value 12 for CLIENT_BASE in enum Config.DeviceConfig.Role

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -108,6 +108,14 @@ message Config {
        *    consuming hops.
        */
       ROUTER_LATE = 11;
+
+      /*
+       * Description: Treats packets from or to favorited nodes as ROUTER, and all other packets as CLIENT.
+       * Technical Details: Used for stronger attic/roof nodes to distribute messages more widely
+       *    from weaker, indoor, or less-well-positioned nodes. Recommended for users with multiple nodes
+       *    where one CLIENT_BASE acts as a more powerful base station, such as an attic/roof node.
+       */
+      CLIENT_BASE = 12;
     }
 
     /*


### PR DESCRIPTION
Adds `CLIENT_BASE = 12` as a new Role.

See https://github.com/meshtastic/firmware/issues/7863 "CLIENT_BASE mode: ROUTER for favorites, CLIENT otherwise (for attic/roof nodes!)"