### PR TITLE
add node_name_length option

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -811,6 +811,12 @@ message Config {
      * If true, the device will display the time in 12-hour format on screen.
      */
     bool use_12h_clock = 12;
+
+    /*
+     * If false (default), the device will use short names for various display screens.
+     * If true, node names will show in long format
+     */
+    bool use_long_node_name = 13;
   }
 
   /*


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?

Adds an option to protobufs (per comment below) to allow choosing node name lengths when displaying on an OLED display.

I'm not sure if this is complete, or if it is even in the right spot. I could see it living in either `config.proto` or `device_ui.proto`

<!-- Please remove or replace the issue url -->

> Please see this [comment](https://github.com/meshtastic/firmware/pull/7926#discussion_r2331910610) on why this PR is being submitted.

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions