### PR TITLE
Add manually_verified bit to SharedContact

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -526,6 +526,11 @@ message SharedContact {
    * Add this contact to the blocked / ignored list
    */
   bool should_ignore = 3;
+
+  /*
+   * Set the IS_KEY_MANUALLY_VERIFIED bit
+   */
+  bool manually_verified = 4;
 }
 
 /*


### PR DESCRIPTION
Currently we are always setting the node as manually verified, but this should be intentional only.