### PR TITLE
Add number of dropped packets to LocalStats

### DIFF
--- a/meshtastic/telemetry.options
+++ b/meshtastic/telemetry.options
@@ -7,6 +7,7 @@
 
 *LocalStats.num_online_nodes int_size:16
 *LocalStats.num_total_nodes int_size:16
+*LocalStats.num_tx_dropped int_size:16
 
 *HealthMetrics.heart_bpm int_size:8
 *HealthMetrics.spO2 int_size:8

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -438,6 +438,11 @@ message LocalStats {
    * Number of bytes free in the heap
    */
   uint32 heap_free_bytes = 13;
+
+  /*
+   * Number of packets that were dropped because the transmit queue was full.
+   */
+  uint32 num_tx_dropped = 14;
 }
 
 /*


### PR DESCRIPTION
This is required for https://github.com/meshtastic/firmware/issues/8056.

This number *should* not be too big, so I chose to use 16 bits.
