### PR TITLE
Telemetry database

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -701,3 +701,13 @@ message SEN5X_config {
    */
   optional bool set_one_shot_mode = 2;
 }
+
+  /*
+   * Telemetry recovery command
+   */
+message Telemetry_Recovery {
+  /*
+   * Air quality telemetry recovery command
+   */
+  bool air_quality_recovery = 1;
+}

--- a/meshtastic/telemetry.options
+++ b/meshtastic/telemetry.options
@@ -16,3 +16,5 @@
 *HostMetrics.load5 int_size:16
 *HostMetrics.load15 int_size:16
 *HostMetrics.user_string max_size:200
+
+*TelemetryDatabase.records max_count:10

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -851,3 +851,28 @@ message SEN5XState {
    */
   optional fixed64 voc_state_array = 6;
 }
+
+/*
+ * Database record wrapper for storing telemetry with metadata
+ */
+message TelemetryDatabaseRecord {
+  /*
+   * Telemetry data
+   */
+  Telemetry telemetry = 1;
+
+  /*
+   * Delivery status flags
+   */
+  bool delivered = 2;
+}
+
+/*
+ * Telemetry database
+ */
+message TelemetryDatabase {
+  /*
+   * List of database records
+   */
+  repeated TelemetryDatabaseRecord records = 1;
+}


### PR DESCRIPTION
A draft idea for a telemetry database storing telemetry historic data in the node.

This is similar in concept, although not developed to the same extent yet as: https://docs.smartcitizen.me/hardware/firmware/?h=flash#flash-storage

However, this implementation uses protobufs for encoding/decoding into flash, and to keep a small DB on runtime.

Rebased onto https://github.com/meshtastic/protobufs/pull/852