### PR TITLE
Add use_aead field to ChannelSettings for AES-CCM channel encryption

### DIFF
--- a/meshtastic/channel.proto
+++ b/meshtastic/channel.proto
@@ -87,6 +87,15 @@ message ChannelSettings {
    * Per-channel module settings.
    */
   ModuleSettings module_settings = 7;
+
+  /*
+   * Enable authenticated encryption (AES-CCM) for this channel.
+   * When true, messages include a 12-byte authentication tag that prevents
+   * forgery and bit-flipping attacks. All nodes on the channel must have
+   * this enabled — unauthenticated (AES-CTR) packets are rejected.
+   * Experimental. Default: false (standard AES-CTR encryption).
+   */
+  bool use_aead = 8;
 }
 
 /*


### PR DESCRIPTION
## Summary

- Add `bool use_aead = 8` to the `ChannelSettings` message in `channel.proto`
- Enables optional AES-CCM authenticated encryption on PSK channels
- When `true`, messages include a 12-byte auth tag preventing forgery and bit-flipping
- Defaults to `false` (standard AES-CTR encryption, no behavior change)

## Context

This field is required by the firmware implementation of AEAD for PSK channels ([firmware#4030](https://github.com/meshtastic/firmware/issues/4030)). Design validated by @pqcfox (applied cryptographer).

**Parameters**: 12-byte auth tag, no CTR fallback on AEAD-enabled channels, experimental labeling.

The companion firmware PR will be submitted against `meshtastic/firmware` once this protobuf change is available.

## Test plan

- [ ] Protobuf compiles with `protoc` without errors
- [ ] Field number 8 does not conflict with existing fields (next after `module_settings = 7`)
- [ ] Default `false` preserves backward compatibility — existing nodes unaffected
- [ ] Firmware PR validates encrypt/decrypt round-trip with 10 unit test sub-cases