### PR TITLE
Experminental PR for adding metadata to protobufs

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -399,12 +399,12 @@ message Config {
     /*
      * (Re)define GPS_RX_PIN for your board.
      */
-     uint32 rx_gpio = 8 [(meshtastic.config_field).diy_only = true];
+    uint32 rx_gpio = 8 [(meshtastic.diy_only) = true];
 
     /*
      * (Re)define GPS_TX_PIN for your board.
      */
-     uint32 tx_gpio = 9 [(meshtastic.config_field).diy_only = true];
+    uint32 tx_gpio = 9 [(meshtastic.diy_only) = true];
 
     /*
      * The minimum distance in meters traveled (since the last send) before we can send a position to the mesh if position_broadcast_smart_enabled

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package meshtastic;
 
 import "meshtastic/device_ui.proto";
+import "meshtastic/field_metadata.proto";
 
 option csharp_namespace = "Meshtastic.Protobufs";
 option go_package = "github.com/meshtastic/go/generated";
@@ -398,12 +399,12 @@ message Config {
     /*
      * (Re)define GPS_RX_PIN for your board.
      */
-    uint32 rx_gpio = 8;
+     uint32 rx_gpio = 8 [(meshtastic.config_field).diy_only = true];
 
     /*
      * (Re)define GPS_TX_PIN for your board.
      */
-    uint32 tx_gpio = 9;
+     uint32 tx_gpio = 9 [(meshtastic.config_field).diy_only = true];
 
     /*
      * The minimum distance in meters traveled (since the last send) before we can send a position to the mesh if position_broadcast_smart_enabled

--- a/meshtastic/field_metadata.proto
+++ b/meshtastic/field_metadata.proto
@@ -10,12 +10,8 @@ option java_outer_classname = "FieldMetadataProtos";
 option java_package = "org.meshtastic.proto";
 option swift_prefix = "";
 
-// Metadata attached to config fields via FieldOptions.
-message ConfigFieldMetadata {
-  required bool diy_only = 1 [default = false];
-}
-
 extend google.protobuf.FieldOptions {
   // Private-use extension number range is 50000-99999.
-  optional ConfigFieldMetadata config_field = 51001;
+  // Field is only relevant to DIY hardware builds.
+  optional bool diy_only = 51001 [default = false];
 }

--- a/meshtastic/field_metadata.proto
+++ b/meshtastic/field_metadata.proto
@@ -1,0 +1,21 @@
+syntax = "proto2";
+
+package meshtastic;
+
+import "google/protobuf/descriptor.proto";
+
+option csharp_namespace = "Meshtastic.Protobufs";
+option go_package = "github.com/meshtastic/go/generated";
+option java_outer_classname = "FieldMetadataProtos";
+option java_package = "org.meshtastic.proto";
+option swift_prefix = "";
+
+// Metadata attached to config fields via FieldOptions.
+message ConfigFieldMetadata {
+  required bool diy_only = 1 [default = false];
+}
+
+extend google.protobuf.FieldOptions {
+  // Private-use extension number range is 50000-99999.
+  optional ConfigFieldMetadata config_field = 51001;
+}


### PR DESCRIPTION
Can we set devices to DIY vs fully-assembled, and then hide the diy-only options in the apps when connected to a pre-assembled board? Let's find out!