### PR TITLE
feat(config): add radar view fields to DisplayConfig

### DIFF
--- a/meshtastic/device_ui.proto
+++ b/meshtastic/device_ui.proto
@@ -95,6 +95,16 @@ message DeviceUIConfig {
   GpsCoordinateFormat gps_format = 19;
 
   /*
+   * When true, the bearings/distance frame is replaced by the radar overlay.
+   */
+  bool bearings_view_radar = 20;
+
+  /*
+   * When true, the radar overlay only plots favorite nodes.
+   */
+  bool radar_favorites_only = 21;
+
+  /*
    * How the GPS coordinates are displayed on the OLED screen.
    */
   enum GpsCoordinateFormat {


### PR DESCRIPTION
## Summary

Two persisted UI flags for the radar minimap feature, added to `Config.DisplayConfig` next to the other compass/screen options:

- `bearings_view_radar` (field 15) - when true, the bearings/distance screen is replaced by the radar minimap
- `radar_favorites_only` (field 16) - when true, the radar minimap only plots favorite nodes

Both are `bool` with fresh field numbers, so default false keeps existing behaviour.

## Context

Required by the radar minimap feature in the firmware: https://github.com/meshtastic/firmware/pull/10224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to display a radar-style minimap instead of the bearings and distance screen.
  * Added an option to limit radar results to favorite nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->