### PR TITLE
Add AS3935 lightning sensor telemetry fields

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -814,6 +814,11 @@ message SensorConfig {
    * SEN6X PM/RHT/VOC/NOx/CO2/HCHO Sensor configuration
    */
   SEN6X_config sen6x_config = 6;
+
+  /*
+   * AS3935 lightning sensor configuration
+   */
+  AS3935_config as3935_config = 7;
 }
 
 message SCD4X_config {
@@ -956,4 +961,12 @@ message DS248X_config {
    * Main channel for temperature reporting (0-7)
    */
   optional uint32 main_temperature_channel = 1;
+}
+
+message AS3935_config {
+  /*
+   * Antenna tuning capacitance in pF, 0 to 120 in steps of 8. The antenna tank must
+   * resonate within 3.5% of 500kHz; the correct trim is specific to the sensor board.
+   */
+  optional uint32 set_tuning_cap_pf = 1;
 }

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -158,6 +158,18 @@ message EnvironmentMetrics {
    * One-wire temperature (*C)
    */
   repeated float one_wire_temperature = 23;
+
+  /*
+   * Lightning strikes detected in the last hour
+   */
+  optional uint32 lightning_strike_count_1h = 24;
+
+  /*
+   * Estimated distance to the leading edge of the storm for the most recently detected
+   * lightning strike in the current window, in km (only meaningful if a genuine strike,
+   * not noise/disturber, was classified this window)
+   */
+  optional float lightning_distance_km = 25;
 }
 
 /*
@@ -896,6 +908,11 @@ enum TelemetrySensorType {
    * SPA06 pressure and temperature
    */
   SPA06 = 54;
+
+  /*
+   * AS3935 Franklin lightning sensor
+   */
+  AS3935 = 55;
 }
 
 /*

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -1027,6 +1027,17 @@ message Nau7802Config {
 }
 
 /*
+ * AS3935 lightning sensor configuration, for saving to flash
+ */
+message AS3935Config {
+  /*
+   * Antenna tuning capacitance in pF, 0 to 120 in steps of 8. The chip does not retain
+   * this across power loss, so it is stored here and re-applied on every boot.
+   */
+  uint32 tuning_cap_pf = 1;
+}
+
+/*
  * SEN5X State, for saving to flash (to be merged with SEN6XState)
  */
 message SEN5XState {

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -1004,7 +1004,7 @@ enum TelemetrySensorType {
    * Sensirion SEN6X PM/RHT/VOC/NOx/CO2/HCHO sensor family (SEN62, SEN63C, SEN65, SEN66, SEN68, SEN69C)
    */
   SEN6X = 56;
-  
+
   /*
    * AS3935 Franklin lightning sensor
    */


### PR DESCRIPTION
# What does this PR do?

Adds the schema needed to support an AS3935 lightning-detection sensor in `meshtastic/firmware` (companion firmware PR: https://github.com/meshtastic/firmware/pull/10931, branch `feat/as3935-lightning-sensor` on `mesh-malaysia/meshtastic-firmware`).

In `meshtastic/telemetry.proto`:

- `EnvironmentMetrics.lightning_strike_count_1h` (`uint32`, field 24) — lightning strikes detected in the last hour, matching the `rainfall_1h` naming convention.
- `EnvironmentMetrics.lightning_distance_km` (`float`, field 25) — estimated distance to the leading edge of the storm for the most recently detected strike in the current window, valid only when a genuine strike (not noise/disturber) was classified.
- `TelemetrySensorType.AS3935` (enum value 55).

Field numbers were the next free slots in both `EnvironmentMetrics` (last used: 23, `one_wire_temperature`) and `TelemetrySensorType` (last used: 54, `SPA06`).

> [Related Issue](https://github.com/meshtastic/firmware/issues/10774)

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions

---

*Note: this repo's `develop` branch (not `master`) is what `meshtastic/firmware`'s own `develop` branch submodule-pins to — this PR targets `develop` accordingly.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for AS3935 lightning sensors.
  - Added configurable antenna tuning capacitance.
  - Added lightning telemetry, including one-hour strike counts and estimated storm distance.
  - Added AS3935 as a supported telemetry sensor type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->