### PR TITLE
feat: report pending direct-message key exchanges

### DIFF
--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -52,6 +52,7 @@
 *QueueStatus.res int_size:8
 *QueueStatus.free int_size:8
 *QueueStatus.maxlen int_size:8
+*QueueStatus.state int_size:8
 
 *ToRadio.payload_variant anonymous_oneof:true
 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2274,6 +2274,21 @@ message LogRecord {
 }
 
 message QueueStatus {
+  /*
+   * Lifecycle state for the mesh packet identified by mesh_packet_id.
+   * Clients that do not recognize this field should retain their existing
+   * queue-status behavior.
+   */
+  enum State {
+    STATE_UNSPECIFIED = 0;
+
+    /*
+     * The device is holding a direct message while it requests the
+     * recipient's NodeInfo to obtain a public encryption key.
+     */
+    KEY_EXCHANGE = 1;
+  }
+
   /* Last attempt to queue status, ErrorCode */
   int32 res = 1;
 
@@ -2285,6 +2300,9 @@ message QueueStatus {
 
   /* What was mesh packet id that generated this response? */
   uint32 mesh_packet_id = 4;
+
+  /* Current lifecycle state for mesh_packet_id */
+  State state = 5;
 }
 
 /*


### PR DESCRIPTION
## Summary
- add an additive `QueueStatus.state` lifecycle enum
- report `KEY_EXCHANGE` against the original mesh packet ID while a sender requests a missing recipient public key

## Compatibility
Existing clients ignore the new field and retain current queue-status behavior. Updated clients can update the existing pending message row by `mesh_packet_id`; no message retry or duplicate ID is required.

## Validation
- `npx --yes @bufbuild/buf lint`