### PR TITLE
fix(kmp): derive the snapshot version without blocking the configuration cache

### DIFF
--- a/packages/kmp/build.gradle.kts
+++ b/packages/kmp/build.gradle.kts
@@ -12,12 +12,21 @@ version = providers.gradleProperty("VERSION_NAME").orElse(
         // derive a snapshot version by patch-bumping the latest git tag. Any
         // failure — git missing, shallow/tagless clone, or an unexpected tag
         // format — degrades to 0.0.1-SNAPSHOT instead of breaking configuration.
+        //
+        // Uses providers.exec rather than ProcessBuilder: starting a process
+        // directly at configuration time is rejected outright under the
+        // configuration cache ("external process started 'git describe …' …
+        // is unsupported"), which made this build impossible to run with
+        // --configuration-cache. providers.exec records the invocation as a
+        // configuration-cache input instead.
         val tag = runCatching {
-            val process = ProcessBuilder("git", "describe", "--tags", "--abbrev=0")
-                .directory(rootDir)
-                .start()
-            val out = process.inputStream.bufferedReader().readText().trim()
-            if (process.waitFor() == 0) out else ""
+            providers.exec {
+                workingDir = rootDir
+                commandLine("git", "describe", "--tags", "--abbrev=0")
+                // A tagless or shallow clone exits non-zero; fall through to
+                // the 0.0.0 defaults below rather than failing the build.
+                isIgnoreExitValue = true
+            }.standardOutput.asText.get().trim()
         }.getOrDefault("")
 
         val parts = tag.removePrefix("v").split(".")


### PR DESCRIPTION
`packages/kmp` currently cannot be built with `--configuration-cache` at all:

```
* What went wrong:
Configuration cache problems found in this build.

1 problem was found storing the configuration cache.
- Build file 'build.gradle.kts': external process started 'git describe --tags --abbrev=0'
> Starting an external process 'git describe --tags --abbrev=0' during configuration
  time is unsupported.
```

The `VERSION_NAME` fallback — which patch-bumps the latest git tag for local
snapshot builds — started git through `ProcessBuilder` directly. Gradle rejects
that outright under the configuration cache.

## The change

Use `providers.exec` instead. It is the configuration-cache-aware equivalent:
the invocation is recorded as a configuration-cache input rather than being an
unsupported side effect.

**Behaviour is unchanged**, including both degradation paths:

- the `runCatching` wrapper still covers a missing `git` binary;
- `isIgnoreExitValue = true` keeps a tagless or shallow clone on the existing
  `0.0.1-SNAPSHOT` path instead of failing configuration.

## Verification

| Command | Before | After |
| --- | --- | --- |
| `./gradlew help --configuration-cache` | FAILED | entry **stored**, then **reused** |
| `./gradlew build --configuration-cache` | FAILED | **BUILD SUCCESSFUL**, 79 tasks |
| derived version | `2.7.27-SNAPSHOT` | `2.7.27-SNAPSHOT` (identical) |

## Scope

This only *unblocks* the configuration cache — it does not enable it.
`gradle.properties` still leaves it off, so nothing changes for CI or for
anyone not passing the flag. Turning it on is a separate call, worth making
once there is Build Scan data to measure the win (see #1027).

Found while onboarding this repo to Develocity (#1027); the CC-reuse check in
that PR's verification could not be run because of this.

## Rebased 2026-09-14

Rebased onto current `master` (55 commits of drift). One conflict, in the
comment block: upstream's em-dash sweep rewrote the two lines this change
inserts after. Kept master's ASCII text and the new paragraph, and replaced the
ellipses in the quoted error with `...` so the widened `ascii-dash` gate stays
happy.

Re-verified on the rebased head against Gradle 9.7.1:

| Command | `master` | this branch |
| --- | --- | --- |
| `packages/kmp/gradlew help --configuration-cache` | FAILED, `external process started 'git describe --tags --abbrev=0'` | `Configuration cache entry stored.` |
| derived fallback version (no `-PVERSION_NAME`) | - | `2.8.1-SNAPSHOT` (latest tag is now `v2.8.0`) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection for tagless and shallow repository checkouts.
  * Builds now continue using fallback versioning when Git tag lookup is unavailable or unsuccessful.

* **Build Improvements**
  * Improved compatibility with Gradle’s configuration cache.
  * Git version lookup now runs consistently from the repository root, supporting more reliable builds across different checkout configurations.
  * Added automatic generation of field metadata for reflection-free integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
