### PR TITLE
Add on-demand GPS position update request

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -479,6 +479,13 @@ message AdminMessage {
     KeyVerificationAdmin key_verification = 67;
 
     /*
+     * Request an immediate GPS sampling cycle. This does not change the
+     * configured GPS or position broadcast intervals. Requests received
+     * within 10 seconds are coalesced and use the most recent fix.
+     */
+    bool request_position_update = 70;
+
+    /*
      * Tell the node to factory reset config everything; all device state and configuration will be returned to factory defaults and BLE bonds will be cleared.
      */
     int32 factory_reset_device = 94;


### PR DESCRIPTION
## Summary

Adds an AdminMessage field that requests an immediate GPS sampling cycle. Repeated requests within 10 seconds are coalesced.

## Compatibility

Uses the new optional field tag 70; existing clients ignore it.

## Testing

- Buf build, lint, and format checks run in CI.