### PR TITLE
Add LoRaWANBridge message for portnum 75

### DIFF
--- a/meshtastic/lorawan_bridge.options
+++ b/meshtastic/lorawan_bridge.options
@@ -1,4 +1,7 @@
-# Sized so the encoded message fits Data.payload at 233 bytes.
+# Sized so the encoded message fits a PKI directed packet, not just a PSK
+# channel one. The firmware gates on the encoded Data: MAX_LORA_PAYLOAD_LEN 255
+# less a 16 byte header leaves 239, and a further 12 bytes of PKC overhead
+# leaves 227. Data costs 5 on top of this message, so the ceiling is 222.
 # Head and continuation share a maximum, so a sender may split anywhere.
 *LoRaWANBridge.Uplink.rssi_x10 int_size:16
 *LoRaWANBridge.Uplink.snr_x10 int_size:16
@@ -6,17 +9,17 @@
 *LoRaWANBridge.Uplink.fsk_bitrate int_size:16
 *LoRaWANBridge.Uplink.payload_id int_size:8
 *LoRaWANBridge.Uplink.chunk_count int_size:8
-*LoRaWANBridge.Uplink.payload max_size:190
+*LoRaWANBridge.Uplink.payload max_size:183
 
 *LoRaWANBridge.Downlink.radio_params int_size:8
 *LoRaWANBridge.Downlink.power_dbm int_size:8
 *LoRaWANBridge.Downlink.request_id int_size:8
 *LoRaWANBridge.Downlink.payload_id int_size:8
 *LoRaWANBridge.Downlink.chunk_count int_size:8
-*LoRaWANBridge.Downlink.payload max_size:190
+*LoRaWANBridge.Downlink.payload max_size:183
 
 *LoRaWANBridge.TxResult.request_id int_size:8
 
 *LoRaWANBridge.PayloadChunk.payload_id int_size:8
 *LoRaWANBridge.PayloadChunk.chunk_index int_size:8
-*LoRaWANBridge.PayloadChunk.payload_chunk max_size:190
+*LoRaWANBridge.PayloadChunk.payload_chunk max_size:183

--- a/meshtastic/lorawan_bridge.options
+++ b/meshtastic/lorawan_bridge.options
@@ -1,0 +1,22 @@
+# Sized so the encoded message fits Data.payload at 233 bytes.
+# Head and continuation share a maximum, so a sender may split anywhere.
+*LoRaWANBridge.Uplink.rssi_x10 int_size:16
+*LoRaWANBridge.Uplink.snr_x10 int_size:16
+*LoRaWANBridge.Uplink.radio_params int_size:8
+*LoRaWANBridge.Uplink.fsk_bitrate int_size:16
+*LoRaWANBridge.Uplink.payload_id int_size:8
+*LoRaWANBridge.Uplink.chunk_count int_size:8
+*LoRaWANBridge.Uplink.payload max_size:190
+
+*LoRaWANBridge.Downlink.radio_params int_size:8
+*LoRaWANBridge.Downlink.power_dbm int_size:8
+*LoRaWANBridge.Downlink.request_id int_size:8
+*LoRaWANBridge.Downlink.payload_id int_size:8
+*LoRaWANBridge.Downlink.chunk_count int_size:8
+*LoRaWANBridge.Downlink.payload max_size:190
+
+*LoRaWANBridge.TxResult.request_id int_size:8
+
+*LoRaWANBridge.PayloadChunk.payload_id int_size:8
+*LoRaWANBridge.PayloadChunk.chunk_index int_size:8
+*LoRaWANBridge.PayloadChunk.payload_chunk max_size:190

--- a/meshtastic/lorawan_bridge.proto
+++ b/meshtastic/lorawan_bridge.proto
@@ -1,0 +1,214 @@
+syntax = "proto3";
+
+package meshtastic;
+
+option csharp_namespace = "Meshtastic.Protobufs";
+option go_package = "github.com/meshtastic/go/generated";
+option java_outer_classname = "LoRaWANBridgeProtos";
+option java_package = "org.meshtastic.proto";
+option swift_prefix = "";
+
+/*
+ * Payload for LORAWAN_BRIDGE packets. Tunnels raw LoRaWAN PHY payloads and their
+ * RF metadata so a gateway can reach a network server over a mesh.
+ */
+message LoRaWANBridge {
+  /*
+   * An uplink heard by the gateway, travelling towards the network server.
+   */
+  message Uplink {
+    /*
+     * Receive frequency in Hz.
+     */
+    fixed32 freq_hz = 1;
+
+    /*
+     * Concentrator receive timestamp in microseconds. Free running, wraps about
+     * every 72 minutes.
+     */
+    fixed32 tmst = 2;
+
+    /*
+     * Received signal strength in tenths of a dBm. Fits signed 16 bit.
+     */
+    sint32 rssi_x10 = 3;
+
+    /*
+     * Signal to noise ratio in tenths of a dB. Fits signed 16 bit.
+     */
+    sint32 snr_x10 = 4;
+
+    /*
+     * Packed radio settings, 0 to 255. Meaningless when fsk_bitrate is set.
+     *   bits 7-5  0 to 7 for SF5 to SF12
+     *   bits 4-2  bandwidth in kHz: 0 125, 1 250, 2 500, 3 203.125, 4 406.25,
+     *             5 812.5, 6 1625, 7 reserved. Codes 0 to 2 are the sub-GHz set
+     *             and 3 to 6 the 2.4 GHz set; the two do not overlap. Any future
+     *             bandwidth takes the next free code rather than sorting in.
+     *   bits 1-0  0 to 3 for 4/5 to 4/8
+     */
+    uint32 radio_params = 5;
+
+    /*
+     * FSK bit rate in bits per second. Non-zero only for an FSK frame, in which
+     * case radio_params does not apply. Fits unsigned 16 bit.
+     */
+    uint32 fsk_bitrate = 9;
+
+    /*
+     * PHY payload, or its first part when chunk_count is 2.
+     */
+    bytes payload = 6;
+
+    /*
+     * Groups this head with its continuation. 1 to 255, or 0 when not chunked.
+     */
+    uint32 payload_id = 7;
+
+    /*
+     * 0 when the frame fits one packet, otherwise 2.
+     */
+    uint32 chunk_count = 8;
+  }
+
+  /*
+   * A downlink from the network server, travelling towards the gateway.
+   */
+  message Downlink {
+    /*
+     * Transmit frequency in Hz.
+     */
+    fixed32 freq_hz = 1;
+
+    /*
+     * Concentrator timestamp to transmit at. Ignored when immediate is set.
+     */
+    fixed32 tmst = 2;
+
+    /*
+     * Packed radio settings, encoded as in Uplink.radio_params. FSK downlink is
+     * not supported, so there is no bit rate or frequency deviation here.
+     */
+    uint32 radio_params = 3;
+
+    /*
+     * Transmit power in dBm, 0 to 255. The gateway clamps it to its region.
+     */
+    uint32 power_dbm = 4;
+
+    /*
+     * Transmit as soon as possible instead of at tmst. Used for Class C.
+     */
+    bool immediate = 5;
+
+    /*
+     * Invert LoRa polarity. True for every LoRaWAN downlink.
+     */
+    bool invert_polarity = 6;
+
+    /*
+     * Disable the physical layer CRC.
+     */
+    bool no_crc = 7;
+
+    /*
+     * Allow the gateway to send this in a later receive window if it arrives too
+     * late. Leave clear for anything tied to a specific uplink.
+     */
+    bool may_defer = 8;
+
+    /*
+     * Identifies this downlink so its TxResult can be matched to it. 1 to 255.
+     */
+    uint32 request_id = 12;
+
+    /*
+     * PHY payload, or its first part when chunk_count is 2.
+     */
+    bytes payload = 9;
+
+    /*
+     * Groups this head with its continuation. 1 to 255, or 0 when not chunked.
+     */
+    uint32 payload_id = 10;
+
+    /*
+     * 0 when the frame fits one packet, otherwise 2.
+     */
+    uint32 chunk_count = 11;
+  }
+
+  /*
+   * The remainder of a chunked Uplink or Downlink. Carries no RF metadata.
+   */
+  message PayloadChunk {
+    /*
+     * Matches payload_id in the head message. Reassembly keys on the sending
+     * node and this value.
+     */
+    uint32 payload_id = 1;
+
+    /*
+     * Position of this chunk. Always 1.
+     */
+    uint32 chunk_index = 2;
+
+    /*
+     * This part of the PHY payload.
+     */
+    bytes payload_chunk = 3;
+  }
+
+  /*
+   * The outcome of a downlink, reported back towards the network server.
+   */
+  message TxResult {
+    /*
+     * Values 0 to 7 mirror the Semtech TX_ACK error field. Keep every value non
+     * negative; enums encode as int32.
+     */
+    enum Status {
+      NONE = 0;
+      TOO_LATE = 1;
+      TOO_EARLY = 2;
+      COLLISION_PACKET = 3;
+      COLLISION_BEACON = 4;
+      TX_FREQ = 5;
+      TX_POWER = 6;
+      GPS_UNLOCKED = 7;
+
+      /*
+       * Held by the gateway for a later receive window.
+       */
+      DEFERRED = 8;
+
+      /*
+       * Discarded, either undeferrable or refused by an authorization check.
+       */
+      DROPPED = 9;
+    }
+
+    /*
+     * The tmst the downlink was scheduled for. Zero when it was immediate, so
+     * diagnostic only; correlate on request_id.
+     */
+    fixed32 tmst = 1;
+
+    /*
+     * What happened to it.
+     */
+    Status status = 2;
+
+    /*
+     * Echoes Downlink.request_id.
+     */
+    uint32 request_id = 3;
+  }
+
+  oneof variant {
+    Uplink uplink = 1;
+    Downlink downlink = 2;
+    TxResult tx_result = 3;
+    PayloadChunk chunk = 4;
+  }
+}

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -242,7 +242,7 @@ enum PortNum {
 
   /*
    * LoraWAN Payload Transport
-   * ENCODING: compact binary LoRaWAN uplink (10-byte RF metadata + PHY payload) - see LoRaWANBridgeModule
+   * ENCODING: LoRaWANBridge protobuf, see lorawan_bridge.proto
    */
   LORAWAN_BRIDGE = 75;
 


### PR DESCRIPTION
Replaces the compact binary encoding documented on `LORAWAN_BRIDGE` with a protobuf message carrying uplinks, downlinks and transmit results. Nothing is deployed against the old encoding.

## Why

Downlink support needs fields the compact format has no room for:

- `tmst`, the concentrator timestamp an uplink was received at. The network server echoes it back in a downlink to say when to transmit, so it has to survive the round trip unmodified.
- `power_dbm`, `invert_polarity`, `no_crc` for the transmit parameters.
- `may_defer`, so a sender can mark a downlink as safe to hold for a later receive window. Join accepts and acknowledgements are bound to a specific uplink and must not be delayed.

## Chunking

A LoRaWAN PHY payload reaches 255 bytes and does not fit one mesh packet. `PayloadChunk` carries the remainder, keyed to the head message by `payload_id`. The head carries the RF metadata so it is not repeated per chunk. Both `payload_id` and `chunk_count` default to zero, which proto3 omits, so an unchunked frame pays nothing for the mechanism.

## Sizing

The whole message has to fit `Data.payload` at 233 bytes. Small fields are pinned to the width they actually need, which brings nanopb's worst case encoding to:

| Message | Encoded size |
| --- | --- |
| `LoRaWANBridge` | 231 |
| `Downlink` | 228 |
| `Uplink` | 225 |
| `PayloadChunk` | 224 |
| `TxResult` | 7 |

A 255 byte PHY payload splits 195 + 60 and needs one continuation.

The value range of each pinned field is documented in the proto, so implementations that do not read the nanopb options stay inside them.

## Verification

`buf lint` passes and `buf format` reports no diff. Generated with nanopb 0.4.9.1 to confirm the sizes above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tunneling LoRaWAN uplinks and downlinks across the mesh.
  * Added RF metadata, payload chunking, downlink transmission controls, and transmission status reporting.
  * Added support for payloads up to 183 bytes, with encoded message and chunk size limits.

* **Documentation**
  * Updated LoRaWAN bridge documentation to describe the protobuf-based message format, payload handling, metadata, chunking, and transmission results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->