### PR TITLE
Add reading intervals and telemetry records

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -84,6 +84,11 @@ message ModuleConfig {
      * Settings for reporting information about our node to a map via MQTT
      */
     MapReportSettings map_report_settings = 11;
+
+    /*
+     * If true, we will always upload telemetry via MQTT at reading interval if connected
+     */
+    bool telemetry_uplink_enabled = 12;
   }
 
   /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -679,6 +679,21 @@ message ModuleConfig {
      * Enable/Disable the air quality telemetry measurement module on-device display
      */
     bool air_quality_screen_enabled = 15;
+
+    /*
+     * Power telemetry read interval
+     */
+    uint32 power_telemetry_read_interval = 16;
+
+    /*
+     * Environment telemetry read interval
+     */
+    uint32 environment_telemetry_read_interval = 17;
+
+    /*
+     * Air quality telemetry read interval
+     */
+    uint32 air_quality_telemetry_read_interval = 18;
   }
 
   /*

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -273,6 +273,13 @@ enum PortNum {
   LORA_OTA_APP = 79;
 
   /*
+   * Batched telemetry readings accumulated between publishes, sent as a
+   * TelemetryRecordHistory by SENSOR-role nodes
+   * ENCODING: Protobuf
+   */
+  TELEMETRY_HISTORY_APP = 80;
+
+  /*
    * GroupAlarm integration
    * Used for transporting GroupAlarm-related messages between Meshtastic nodes
    * and companion applications/services.

--- a/meshtastic/telemetry.options
+++ b/meshtastic/telemetry.options
@@ -17,3 +17,5 @@
 *HostMetrics.load5 int_size:16
 *HostMetrics.load15 int_size:16
 *HostMetrics.user_string max_size:200
+
+*TelemetryRecordHistory.readings max_count:16

--- a/meshtastic/telemetry.options
+++ b/meshtastic/telemetry.options
@@ -18,4 +18,6 @@
 *HostMetrics.load15 int_size:16
 *HostMetrics.user_string max_size:200
 
+# Nanopb storage limit. The actual count/size per publication limit is enforced
+# at runtime which shrinks the batch until it fits the 233-byte meshtastic_Data.payload limit.
 *TelemetryRecordHistory.readings max_count:16

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -1103,12 +1103,16 @@ message TelemetryRecord {
   }
 
   /*
-   * Seconds since 1970. Unset if the sender had no real time source.
+   * Seconds since 1970. Unset if the sender had no real time source when captured.
+   * Takes priority when set. A reading never has both time and delta_secs.
    */
   optional fixed32 time = 4;
 
   /*
-   * Seconds since the previous reading in this node's history was captured
+   * Seconds since the node's previous history record was captured. Set only
+   * when time is unset. To reconstruct a time, check the nearest reading in either direction
+   * with a real timestamp and sum deltas between.
+   * If no reading with real timestamp is reachable, mark the last reading's timestamp as reception time.
    */
   optional uint32 delta_secs = 5;
 }

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -1103,19 +1103,19 @@ message TelemetryRecord {
   }
 
   /*
-   * Seconds since 1970 - or 0 for unknown/unset
+   * Seconds since 1970. Unset if the sender had no real time source.
    */
-  fixed32 time = 4;
+  optional fixed32 time = 4;
+
+  /*
+   * Seconds since the previous reading in this node's history was captured
+   */
+  optional uint32 delta_secs = 5;
 }
 
 message TelemetryRecordHistory {
   /*
-   * Interval in seconds between consecutive readings in this batch
-   */
-  uint32 interval_sec = 1;
-
-  /*
    * Telemetry readings, oldest first
    */
-  repeated TelemetryRecord readings = 2;
+  repeated TelemetryRecord readings = 1;
 }

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -1080,3 +1080,42 @@ message SEN6XState {
    */
   optional fixed64 voc_state_array = 6;
 }
+
+message TelemetryRecord {
+  /*
+   * Telemetry variant in telemetry record
+   */
+  oneof telemetry_variant {
+    /*
+     * Environment Telemetry variant
+     */
+    EnvironmentMetrics environment_metrics = 1;
+
+    /*
+     * Power Telemetry variant
+     */
+    PowerMetrics power_metrics = 2;
+
+    /*
+     * Air quality Telemetry variant
+     */
+    AirQualityMetrics air_quality_metrics = 3;
+  }
+
+  /*
+   * Seconds since 1970 - or 0 for unknown/unset
+   */
+  fixed32 time = 4;
+}
+
+message TelemetryRecordHistory {
+  /*
+   * Interval in seconds between consecutive readings in this batch
+   */
+  uint32 interval_sec = 1;
+
+  /*
+   * Telemetry readings, oldest first
+   */
+  repeated TelemetryRecord readings = 2;
+}


### PR DESCRIPTION
This PR adds:

1. Protobuf messages for sending a repeated telemetry messages as a buffer: adds a `TelemetryRecord` and `TelemetryRecordHistory` message types
2. Reading intervals for AirQuality, Environment and Power Telemetry (to decouple reading from publication) as described in https://github.com/meshtastic/firmware/issues/10997
3. A limit of 16 payloads per RecordHistory (which are furter trimmed in firmware if they are too big)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent read-interval settings for power, environmental, and air-quality telemetry.
  * Added an option to enable or disable telemetry uploads via MQTT.
  * Added support for recording telemetry readings with timestamps and time deltas.
  * Added transmission of historical telemetry batches containing up to 16 past readings.
  * Historical telemetry can include power, environmental, or air-quality measurements.
  * Added support for identifying and handling historical telemetry transmissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->