### PR TITLE
Telemetry uplink enabled

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -84,6 +84,11 @@ message ModuleConfig {
      * Settings for reporting information about our node to a map via MQTT
      */
     MapReportSettings map_report_settings = 11;
+
+    /*
+     * If true, we will always upload telemetry via MQTT at reading interval if connected
+     */
+    bool telemetry_uplink_enabled = 12;
   }
 
   /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -679,6 +679,21 @@ message ModuleConfig {
      * Enable/Disable the air quality telemetry measurement module on-device display
      */
     bool air_quality_screen_enabled = 15;
+
+    /*
+     * Power telemetry read interval
+     */
+    uint32 power_telemetry_read_interval = 16;
+
+    /*
+     * Environment telemetry read interval
+     */
+    uint32 environment_telemetry_read_interval = 17;
+
+    /*
+     * Air quality telemetry read interval
+     */
+    uint32 air_quality_telemetry_read_interval = 18;
   }
 
   /*

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -273,6 +273,13 @@ enum PortNum {
   LORA_OTA_APP = 79;
 
   /*
+   * Batched telemetry readings accumulated between publishes, sent as a
+   * TelemetryRecordHistory by SENSOR-role nodes
+   * ENCODING: Protobuf
+   */
+  TELEMETRY_HISTORY_APP = 80;
+
+  /*
    * GroupAlarm integration
    * Used for transporting GroupAlarm-related messages between Meshtastic nodes
    * and companion applications/services.

--- a/meshtastic/telemetry.options
+++ b/meshtastic/telemetry.options
@@ -17,3 +17,5 @@
 *HostMetrics.load5 int_size:16
 *HostMetrics.load15 int_size:16
 *HostMetrics.user_string max_size:200
+
+*TelemetryRecordHistory.readings max_count:16

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -1080,3 +1080,42 @@ message SEN6XState {
    */
   optional fixed64 voc_state_array = 6;
 }
+
+message TelemetryRecord {
+  /*
+   * Telemetry variant in telemetry record
+   */
+  oneof telemetry_variant {
+    /*
+     * Environment Telemetry variant
+     */
+    EnvironmentMetrics environment_metrics = 1;
+
+    /*
+     * Power Telemetry variant
+     */
+    PowerMetrics power_metrics = 2;
+
+    /*
+     * Air quality Telemetry variant
+     */
+    AirQualityMetrics air_quality_metrics = 3;
+  }
+
+  /*
+   * Seconds since 1970 - or 0 for unknown/unset
+   */
+  fixed32 time = 4;
+}
+
+message TelemetryRecordHistory {
+  /*
+   * Interval in seconds between consecutive readings in this batch
+   */
+  uint32 interval_sec = 1;
+
+  /*
+   * Telemetry readings, oldest first
+   */
+  repeated TelemetryRecord readings = 2;
+}


### PR DESCRIPTION
Rebased onto: https://github.com/meshtastic/protobufs/pull/1035.

Adds a moduleConfig to directly upload telemetry via MQTT avoiding the service.sendToMesh / Router if `mesh` is too busy and the node has MQTT enabled.

Second part of: https://github.com/meshtastic/firmware/issues/10997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable telemetry upload support for MQTT.
  - Added independent reporting intervals for power, environmental, and air-quality sensors.
  - Added telemetry history sharing, including timestamped readings and sampling intervals.
  - Added support for transmitting batched telemetry history from sensor nodes.
  - Limited telemetry history batches to 16 readings for efficient transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->