### PR TITLE
Add new firmware editions for Dragon Con and CCC events

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2186,6 +2186,16 @@ enum FirmwareEdition {
   FAB = 20;
 
   /*
+   * Dragon Con, the yearly pop culture convention in Atlanta, GA
+   */
+  DRAGON_CON = 21;
+
+  /*
+   * Chaos Communication Congress, the hacker conference held yearly in Germany
+   */
+  CCC = 22;
+
+  /*
    * Placeholder for DIY and unofficial events
    */
   DIY_EDITION = 127;


### PR DESCRIPTION
# What does this PR do?

Add new event firmware editions for:
- [Dragon Con](https://en.wikipedia.org/wiki/Dragon_Con)
- [Chaos Communication Congress](https://en.wikipedia.org/wiki/Chaos_Communication_Congress)

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Dragon Con and CCC firmware editions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->