### PR TITLE
Add SEEED_WIO_TRACKER_L1_PRO_1W

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -949,6 +949,11 @@ enum HardwareModel {
   HELTEC_RCC6 = 143;
 
   /*
+   * Seeed Wio Tracker L1 Pro 1W, nRF52840 + SX1262 with 1 W external PA
+   */
+  SEEED_WIO_TRACKER_L1_PRO_1W = 144;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
BSP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying the Seeed Wio Tracker L1 Pro 1W hardware model.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->