### PR TITLE
2.7: Backport #1038 - Add SEEED_WIO_TRACKER_L1_PRO_1W

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -934,6 +934,11 @@ enum HardwareModel {
   MESHNOLOGY_W10 = 140;
 
   /*
+   * Seeed Wio Tracker L1 Pro 1W, nRF52840 + SX1262 with 1 W external PA
+   */
+  SEEED_WIO_TRACKER_L1_PRO_1W = 144;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Backports #1038 to the 2.7 maintenance branch, adding `SEEED_WIO_TRACKER_L1_PRO_1W = 144`.

Needed by meshtastic/firmware#11541, which adds the board to the 2.7 line and references the enum from `src/platform/nrf52/architecture.h`.

Value 144 matches the allocation on master. IDs 141 to 143 (HELTEC_RC32, HELTEC_RC52, HELTEC_RCC6) are master-only and stay unused here: hardware model numbers are on-air values, so they must not be renumbered per branch.

Same pattern as #990 (2.7-spa06) and #989 (2.7-hm330x).