### PR TITLE
Add MESHNOLOGY_W12 hardware model

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -954,6 +954,11 @@ enum HardwareModel {
   SEEED_WIO_TRACKER_L1_PRO_1W = 144;
 
   /*
+   * Meshnology W12
+   */
+  MESHNOLOGY_W12 = 145;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Adds the **Meshnology W12** to the `HardwareModel` enum as the next value.

```proto
MESHNOLOGY_W12 = 145;
```

_Entry numbered from the live enum at generation time._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying the Meshnology W12 hardware model.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->