### PR TITLE
Add MESHPAGER_X2 hardware model

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -959,6 +959,11 @@ enum HardwareModel {
   MESHNOLOGY_W12 = 145;
 
   /*
+   * Seeed Studio MeshPager X2
+   */
+  MESHPAGER_X2 = 146;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Adds the **Seeed Studio MeshPager X2** to the `HardwareModel` enum as the next value.

```proto
MESHPAGER_X2 = 146;
```

_Entry numbered from the live enum at generation time._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying the Seeed Studio MeshPager X2 hardware device.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->