### PR TITLE
Add registered PortNum for PRIVEU (end-to-end-encrypted messenger over Meshtastic)

### DIFF
--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -273,6 +273,16 @@ enum PortNum {
   LORA_OTA_APP = 79;
 
   /*
+   * PRIVEU end-to-end-encrypted messenger.
+   * Carries a self-contained authenticated, forward-secret envelope inside
+   * Data.payload; Meshtastic is used as transport only. Messages larger than
+   * one frame are fragmented with a 6-byte reassembly header.
+   *
+   * ENCODING: binary (canonical CBOR)
+   */
+  PRIVEU_APP = 80;
+
+  /*
    * GroupAlarm integration
    * Used for transporting GroupAlarm-related messages between Meshtastic nodes
    * and companion applications/services.


### PR DESCRIPTION
### What this adds

One value in the registered third-party range (64–127) of the `PortNum` enum,
for PRIVEU — an end-to-end-encrypted messenger that uses Meshtastic as a
transport.

`PRIVEU_APP = 80` is the next free value after `LORA_OTA_APP = 79`. Happy to
move it to any other slot you prefer.

### What PRIVEU is

PRIVEU is an end-to-end-encrypted messenger. On the mesh it uses Meshtastic
for transport only — routing, store-and-forward, FEC and ACK — and carries its
own authenticated, forward-secret envelope inside `Data.payload`, so that a
message is sender-authenticated and confidential independently of who holds
the channel key.

### Why a registered PortNum rather than `PRIVATE_APP`

We currently use `PRIVATE_APP = 256` for development, and it is correct for
that. It is not safe for a public deployment: any other project on the same
mesh may use the same value, so two unrelated applications' bytes land in
each other's parsers. Our receivers reject foreign bytes (they fail CBOR
structure validation, then AEAD/signature verification), and we drop them
silently without broadcasting an error — but the collision is still real in
the other direction, and we would rather not hand other `PRIVATE_APP`
consumers a stream of packets they have to reject. A registered value removes
the ambiguity for everyone on the mesh.

Our production build path treats the absence of a registered value as a hard
gate rather than falling back to 256.

### What the PortNum carries

`Data.payload` holds a canonical-CBOR map (deterministic encoding, integer
keys in ascending order, no indefinite-length items, no tags). Fixed fields:
version, ciphersuite id, an 8-byte sender-key hint, a 32-byte X25519
ephemeral public key, a 12-byte AEAD nonce, a 16-byte inner ciphertext
header, a 64-byte Ed25519 signature, a 16-byte AEAD tag, and the body.
Crypto is classical only — Ed25519, X25519, ChaCha20-Poly1305, HKDF-SHA256.

Two on-air shapes:

- **Unfragmented.** `Data.payload` is the whole CBOR map. The fixed header is
  169 bytes measured, so a short message is a ~170–200 byte payload. We cap
  our own container at 256 bytes and never emit a single-packet payload above
  the Meshtastic `DATA_PAYLOAD_LEN` of 237 bytes.
- **Fragmented.** Anything longer is split before framing. Each packet then
  carries a 6-byte fragment header (`u32` random reassembly key, `u8`
  sequence, `u8` total) followed by at most 78 bytes of the encoded envelope
  — an **84-byte payload ceiling per packet**, well inside a single frame.
  Maximum 255 fragments per message. The receiver holds a reassembly window
  for 300 s, keyed on the reassembly key, and drops the whole message if any
  fragment fails authentication — no partial delivery. Duplicate fragments
  (normal with multi-path mesh routing) are dropped silently.

We deliberately do **not** put post-quantum key exchange or signatures on the
LoRa surface: ML-KEM/ML-DSA add kilobytes per envelope and do not fit a
Meshtastic packet. Those stay on our internet transport.

### Traffic pattern and airtime

This is low-rate, human-paced messaging. Concretely, on the LongFast preset
(SF11 / BW 250 kHz / CR 4:5, 16-symbol preamble), using the LoRa datasheet
time-on-air equation:

| Packet | `Data.payload` | Time on air |
|---|---|---|
| One fragment (worst case) | 84 B | ≈ 1.0 s |
| One unfragmented envelope | 169 B | ≈ 1.8 s |
| Largest single-frame packet | 237 B | ≈ 2.4 s |

Against the EU 868 MHz 1% duty cycle (36 s of airtime per rolling hour) that
is roughly 20 unfragmented packets per hour per node, and fewer once the
16-byte packet header and protobuf framing are charged — which our sender
does charge.

Duty cycle is enforced on our side before transmit, not as a convention: a
sliding-window airtime accountant computes the real datasheet time-on-air for
the complete on-air frame and refuses the transmit when the regional budget
is exhausted (EU 868 MHz 1% per rolling hour; US/AU 915 MHz as a 400 ms
cumulative-per-20 s window). A multi-fragment message is admitted or refused
as a whole batch, so we do not start a message we cannot finish inside the
budget.

Deliberate airtime economies:

- Application-level delivery receipts are **never** sent over LoRa. They are
  batched and flushed over an internet connection when one is available.
- Group messaging is not carried over the mesh at all — group state changes
  would multi-fragment on every update. Mesh traffic is 1:1.
- We rely on Meshtastic's own transport ACK and do not add an
  application-level ACK on the air.

### Coexistence

We ride an open channel and emit a byte-exact Meshtastic header, so ordinary
nodes relay our packets on the unencrypted header and hop limit alone,
exactly as they do for any other PortNum they cannot interpret. We ask for no
firmware change, no routing change, and no relay-policy change. Enabling
PRIVEU on a node does not disable or alter that node's default-channel chat
or its relaying of other traffic. We target Meshtastic firmware **2.7.15 or
later** and refuse to pair with anything older.

### Proposed change

```proto
  /*
   * PRIVEU end-to-end-encrypted messenger.
   * Carries a self-contained authenticated, forward-secret envelope inside
   * Data.payload; Meshtastic is used as transport only. Messages larger than
   * one frame are fragmented with a 6-byte reassembly header.
   *
   * ENCODING: binary (canonical CBOR)
   */
  PRIVEU_APP = 80;
```

Additive only — no existing value is renumbered, renamed or removed.
`protoc` parses the file and `buf` breaking-change rules are unaffected by a
new enum value.

Happy to answer anything else that would help review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the PRIVEU secure messaging application.
  * Messages can use authenticated, end-to-end-encrypted envelopes with forward secrecy.
  * Large messages support fragmentation, with a standardized compact binary encoding for reliable transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->