### PR TITLE
Remove unused beacon broadcast_send_as_node field

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -868,14 +868,12 @@ message ModuleConfig {
      */
     uint32 flags = 1;
 
-    /*
-     * Optional: node ID to send beacon messages AS.
-     * When set, the `from` field of outgoing beacon packets is set to this node ID,
-     * making beacons appear to originate from that node.
-     * When unset (0), beacons are sent as the local node.
-     * A remote admin can only set this field to their own node ID.
-     */
-    uint32 broadcast_send_as_node = 3;
+    // Tag 3 was broadcast_send_as_node, a node-ID override that rewrote the `from` field of
+    // outgoing beacon packets so they appeared to originate from another node. Firmware never
+    // applied it (the assignment was left commented out) and it never reached a tagged release,
+    // so it is removed rather than kept as a settable no-op. Reserved to prevent reuse.
+    reserved 3;
+    reserved "broadcast_send_as_node";
 
     /*
      * Message to include in each beacon broadcast. Max 100 bytes enforced by firmware.


### PR DESCRIPTION
Removes `ModuleConfig.MeshBeaconConfig.broadcast_send_as_node` (tag 3).

## What it was

A node ID that outgoing beacons would be sent **as** — it rewrote the packet's `from` field so beacons appeared to originate from another node.

## Why remove it

**Firmware never applied it.** The assignment in `MeshBeaconModule::sendBeacon()` is commented out pending review, so `from` is always `nodeDB->getNodeNum()`. The field is a settable, persisted no-op: a client can write it via `set_module_config`, get an OK, read it back in the config, and see no effect on air. `test/test_mesh_beacon` pins that behavior.

**The mechanism was unsound as designed.** Rewriting `from` forges no signature. It only makes `isFromUs()` false, which causes `Router::perhapsEncode()` to skip XEdDSA signing — receivers would get an *unsigned* packet attributed to another node. The firmware-side comment also notes `has_bitfield` / `ok_to_mqtt` had to be re-stamped by hand because the from-us path stops doing it.

**Nothing depends on it.** Not in any tagged release (`git tag --contains` on the introducing commit `369550b` is empty), and `broadcast_send_as_node` appears nowhere in this repo outside the one line being deleted, nor in any client (checked Android, C#, api, docs).

## Reserved

Tag 3 and the field name are reserved, matching the house style in `deviceonly.proto`.

## Note for reviewers: the breaking check will flag this

`buf.yaml` sets `breaking.use: [FILE]`, whose `FIELD_NO_DELETE` is not satisfied by a `reserved` statement — only the `WIRE`/`WIRE_JSON` variants are. So the `buf breaking` job is expected to report this deletion. That is intentional here given the field is unreleased and unconsumed.

`protoc --proto_path=. -o /dev/null meshtastic/*.proto` passes.

## Firmware follow-up

Not included here — this PR is the proto change only. Once merged, `meshtastic/firmware` needs a submodule bump, regenerated `src/mesh/generated/`, removal of the `broadcast_send_as_node` guard in `AdminModule.cpp` and the commented-out block in `MeshBeaconModule.cpp`, and a `test_mesh_beacon` update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unused MeshBeacon configuration option that could override the sender identity for outgoing beacons.
  * Prevented the retired configuration field from being reused accidentally in future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->