### PR TITLE
Consolidate beacon TX destinations onto broadcast_targets

### DIFF
--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -33,6 +33,4 @@
 *MeshBeaconConfig.broadcast_message max_size:101
 *MeshBeaconConfig.broadcast_offer_channel.name max_size:12
 *MeshBeaconConfig.broadcast_offer_channel.psk max_size:32
-*MeshBeaconConfig.broadcast_on_channel.name max_size:12
-*MeshBeaconConfig.broadcast_on_channel.psk max_size:32
 *MeshBeaconConfig.broadcast_targets max_count:4

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -897,25 +897,14 @@ message ModuleConfig {
      */
     optional Config.LoRaConfig.ModemPreset broadcast_offer_preset = 7;
 
-    /*
-     * Single-target TX channel: channel settings (name + PSK) to send beacons on.
-     * If unset, beacons go out on the primary channel. Used only when broadcast_targets is empty.
-     * NOTE: the single-target path embeds the ChannelSettings inline here, whereas a
-     * broadcast_targets entry references a channel-table slot by channel_index instead — see
-     * BroadcastTarget. The two paths are equal, first-class options; only this representation differs.
-     */
-    ChannelSettings broadcast_on_channel = 8;
-
-    /*
-     * Region to use when sending beacons on broadcast_on_preset.
-     */
-    Config.LoRaConfig.RegionCode broadcast_on_region = 9;
-
-    /*
-     * Modem preset to use when sending beacons.
-     * If different from current config, the radio is temporarily switched for TX.
-     */
-    optional Config.LoRaConfig.ModemPreset broadcast_on_preset = 10;
+    // Tags 8, 9 and 10 were broadcast_on_channel / broadcast_on_region / broadcast_on_preset: a
+    // second way to describe a single beacon destination, used only when broadcast_targets was
+    // empty. Consolidated onto broadcast_targets so there is one way to name a destination.
+    // broadcast_on_channel embedded a ChannelSettings inline, which allowed transmitting on a
+    // channel absent from the node's channel table; that is no longer supported - the channel must
+    // exist on the node. Never in a tagged release. Reserved to prevent reuse.
+    reserved 8, 9, 10;
+    reserved "broadcast_on_channel", "broadcast_on_region", "broadcast_on_preset";
 
     /*
      * How often to broadcast, in seconds. Min 3600 (1 h), default 3600.
@@ -923,8 +912,8 @@ message ModuleConfig {
     uint32 broadcast_interval_secs = 11;
 
     /*
-     * One entry in the multi-target broadcast list.
-     * The broadcaster transmits one beacon copy per entry, each on its own radio settings.
+     * One entry in the broadcast destination list.
+     * Each entry names one set of radio settings to send a beacon copy on.
      */
     message BroadcastTarget {
       /*
@@ -951,15 +940,13 @@ message ModuleConfig {
     }
 
     /*
-     * Multi-target broadcast list.
-     * When non-empty the broadcaster transmits one beacon copy per entry in sequence,
-     * each temporarily switching the radio to that entry's preset/region/channel.
-     * When empty, the broadcaster uses the scalar broadcast_on_preset / broadcast_on_region /
-     * broadcast_on_channel fields instead (the single-target path).
-     * Single- and multi-target are equal, first-class options — neither is preferred or
-     * deprecated. They differ only in how the TX channel is named: broadcast_on_channel embeds a
-     * ChannelSettings inline, while a target references an existing channel-table slot by
-     * channel_index (see BroadcastTarget).
+     * Broadcast destination list.
+     * The broadcaster sends one beacon copy per distinct destination, in sequence, temporarily
+     * switching the radio to that entry's preset/region/channel for each.
+     * When empty, a single beacon is sent on the node's running preset and region over the
+     * primary channel.
+     * Entries that resolve to the same effective preset, region and channel are deduplicated, so
+     * a duplicate entry does not produce a second transmission.
      */
     repeated BroadcastTarget broadcast_targets = 13;
   }


### PR DESCRIPTION
`MeshBeaconConfig` had two ways to say where a beacon should be transmitted, and the firmware silently picked between them.

- `broadcast_on_channel` / `broadcast_on_region` / `broadcast_on_preset` — one destination, channel spelled out inline as a `ChannelSettings`
- `broadcast_targets` — up to four destinations, each naming its channel by channel-table index

If `broadcast_targets` was empty the firmware used the scalars; if it had any entry it ignored the scalars entirely.

## The two were not equivalent

The comments claimed they were "equal, first-class options" differing "only in how the TX channel is named." That was wrong. An inline `ChannelSettings` carries name **and PSK**, so `broadcast_on_channel` could transmit on a channel absent from the node's channel table. `channel_index` can only point at a provisioned slot, so it cannot express that.

Dropping that capability is the deliberate call here: there is no use case for beaconing on a channel the node doesn't have. Provisioning the channel isn't a workaround, it's the intended way to do it.

## Changes

Removes tags 8, 9, 10 and reserves the numbers and names. Empty `broadcast_targets` now means one beacon on the node's running preset and region over the primary channel — the same thing the scalar path produced when left unset, so the "just enable it" behavior is unchanged.

Also corrects two statements about `broadcast_targets` that didn't match the firmware. It said a copy is transmitted "per entry"; the broadcaster deduplicates entries that resolve to the same effective preset/region/channel, so it's per *distinct destination*.

## Size

Measured by regenerating with nanopb 0.4.9, the version `bin/regen-protos.sh` pins:

| | before | after |
|---|---|---|
| `MeshBeaconConfig` | 324 | **246** |
| `ModuleConfig` | 328 | **250** |
| `FromRadio` | 510 | 510 |

78 bytes back against the hard 512-byte `MAX_TO_FROM_RADIO_SIZE` ceiling, which `FromRadio` currently sits 2 bytes under.

For the record, the alternative — keeping inline channels by moving `ChannelSettings` into `BroadcastTarget` — was measured too: at `max_count:4` it puts `FromRadio` at **549** and trips the `#if meshtastic_FromRadio_size > MAX_TO_FROM_RADIO_SIZE` guard. That is the same wall that retired `BroadcastTarget` tag 3. It only fits at `max_count` 3 (454) or 2 (368), i.e. by giving up destinations.

`protoc --proto_path=. -o /dev/null meshtastic/*.proto` passes.

## Notes for reviewers

**The `buf breaking` job will flag this.** `buf.yaml` sets `breaking.use: [FILE]`, whose `FIELD_NO_DELETE` isn't satisfied by a `reserved` statement — only the `WIRE`/`WIRE_JSON` variants are. Intentional: the field never reached a tagged release and has no consumers outside the firmware repo.

**A firmware change must land with the submodule bump.** Unlike meshtastic/protobufs#1047, this one does not leave dead code behind — `MeshBeaconModule.cpp` and `AdminModule.cpp` read `broadcast_on_*` directly, so bumping the submodule without the firmware change will not compile. The firmware side removes the single-target `else` branch of the target loop, the `useTargetList`/`targetCount` split, and the `has_broadcast_on_*` validation block, and needs `broadcast_targets_count == 0` to synthesize one default target.

Independent of meshtastic/protobufs#1047 — different hunks, no conflict, either order merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated mesh beacon configuration to support broadcasting through configured channel-table entries.
  * Added fallback behavior using the active preset, region, and primary channel when destinations are not explicitly configured.
  * Broadcasts are sent sequentially with duplicate destinations automatically removed.

* **Breaking Changes**
  * Removed the legacy single-destination channel, region, and preset settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->