### PR TITLE
Add a beacon frequency slot, name channels by value, and make the target list the only destination

### DIFF
--- a/meshtastic/channel.options
+++ b/meshtastic/channel.options
@@ -3,3 +3,6 @@
 # 256 bit or 128 bit psk key
 *ChannelSettings.psk max_size:32
 *ChannelSettings.name max_size:12
+
+*ChannelIdentity.psk max_size:32
+*ChannelIdentity.name max_size:12

--- a/meshtastic/channel.proto
+++ b/meshtastic/channel.proto
@@ -92,7 +92,7 @@ message ChannelSettings {
    * Enable authenticated encryption (AES-CCM) for this channel.
    * When true, messages include a 12-byte authentication tag that prevents
    * forgery and bit-flipping attacks. All nodes on the channel must have
-   * this enabled — unauthenticated (AES-CTR) packets are rejected.
+   * this enabled - unauthenticated (AES-CTR) packets are rejected.
    * Experimental. Default: false (standard AES-CTR encryption).
    */
   bool use_aead = 8;

--- a/meshtastic/channel.proto
+++ b/meshtastic/channel.proto
@@ -164,3 +164,23 @@ message Channel {
    */
   Role role = 3;
 }
+
+/*
+ * The identity half of a ChannelSettings: the only fields needed to name a channel and decrypt it.
+ * Tag numbers deliberately match ChannelSettings (psk = 2, name = 3), so the two are wire
+ * compatible in both directions: a ChannelSettings decodes as a ChannelIdentity with the remaining
+ * fields skipped as unknown, and a ChannelIdentity decodes as a ChannelSettings with only these
+ * two set. Used where a channel must be named by value rather than by table index - a remote
+ * administrator cannot read the channel table, so an index means nothing to it.
+ */
+message ChannelIdentity {
+  /*
+   * Pre-shared key, same encoding as ChannelSettings.psk, including the 1-byte shorthands.
+   */
+  bytes psk = 2;
+
+  /*
+   * Channel name. Blank means the modem preset's display name, as everywhere else.
+   */
+  string name = 3;
+}

--- a/meshtastic/mesh_beacon.options
+++ b/meshtastic/mesh_beacon.options
@@ -1,3 +1,1 @@
 *MeshBeacon.message max_size:101
-*MeshBeacon.offer_channel.name max_size:12
-*MeshBeacon.offer_channel.psk max_size:32

--- a/meshtastic/mesh_beacon.options
+++ b/meshtastic/mesh_beacon.options
@@ -1,1 +1,1 @@
-*MeshBeacon.message max_size:101
+*MeshBeacon.message max_size:61

--- a/meshtastic/mesh_beacon.proto
+++ b/meshtastic/mesh_beacon.proto
@@ -26,8 +26,12 @@ message MeshBeacon {
   /*
    * Optional channel (name + PSK) being advertised to listening clients.
    * A client app may offer to switch the user to this channel; firmware never applies it automatically.
+   * ChannelIdentity rather than ChannelSettings: only the name and PSK are needed to join, and the
+   * rest of a ChannelSettings - id, uplink_enabled, downlink_enabled, module_settings - described
+   * the advertising node's own posture and had no business on the air. Wire compatible with the
+   * ChannelSettings this tag carried in v2.8.0, in both directions.
    */
-  ChannelSettings offer_channel = 2;
+  ChannelIdentity offer_channel = 2;
 
   /*
    * Optional region being advertised alongside offer_preset.

--- a/meshtastic/mesh_beacon.proto
+++ b/meshtastic/mesh_beacon.proto
@@ -39,4 +39,15 @@ message MeshBeacon {
    * Combined with offer_region, tells a client "there is a mesh on this preset/region".
    */
   optional Config.LoRaConfig.ModemPreset offer_preset = 4;
+
+  /*
+   * Frequency slot this mesh uses, 1-based, matching Config.LoRaConfig.channel_num.
+   * OMITTED when a receiver can derive the slot itself from offer_region, offer_channel's
+   * name and offer_preset - an unset offer_preset means the region's default preset. That
+   * covers both a region with a mandated slot and a mesh on the default name hash.
+   * PRESENT means this mesh deliberately deviates from what derivation would produce; a
+   * client should still validate the result against its own region before offering to join.
+   * Do not send 0 - it is the same as omitting the field.
+   */
+  optional uint32 offer_frequency_slot = 5;
 }

--- a/meshtastic/mesh_beacon.proto
+++ b/meshtastic/mesh_beacon.proto
@@ -19,7 +19,7 @@ option swift_prefix = "";
  */
 message MeshBeacon {
   /*
-   * Human-readable beacon message. Max 100 bytes enforced by firmware on send.
+   * Human-readable beacon message. Max 60 bytes enforced by firmware on send.
    */
   string message = 1;
 

--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -31,6 +31,4 @@
 *StatusMessageConfig.node_status max_size:80
 
 *MeshBeaconConfig.broadcast_message max_size:101
-*MeshBeaconConfig.broadcast_offer_channel.name max_size:12
-*MeshBeaconConfig.broadcast_offer_channel.psk max_size:32
 *MeshBeaconConfig.broadcast_targets max_count:4

--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -30,5 +30,5 @@
 
 *StatusMessageConfig.node_status max_size:80
 
-*MeshBeaconConfig.broadcast_message max_size:101
+*MeshBeaconConfig.broadcast_message max_size:61
 *MeshBeaconConfig.broadcast_targets max_count:4

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -903,7 +903,7 @@ message ModuleConfig {
     reserved "broadcast_send_as_node";
 
     /*
-     * Message to include in each beacon broadcast. Max 100 bytes enforced by firmware.
+     * Message to include in each beacon broadcast. Max 60 bytes enforced by firmware.
      */
     string broadcast_message = 4;
 

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -928,38 +928,29 @@ message ModuleConfig {
     optional Config.LoRaConfig.ModemPreset broadcast_offer_preset = 7;
 
     /*
-     * The single explicit broadcast target, named by value. This is the remote-administration
+     * Default channel for the broadcast targets, named by value. This is the remote-administration
      * path: an administrator that cannot read the channel table states the channel outright.
      * Upserted into the channel table exactly as broadcast_offer_channel is.
-     * Mutually exclusive with broadcast_targets (tag 13), which is the local-administration path.
-     * If both arrive in one message the indexed list wins and these fields are cleared, because
-     * an index cannot mutate the channel table and a by-value entry can.
-     * Unset while broadcast_on_region / _preset / _frequency_slot are set means the node's
-     * primary channel, retuned - the same meaning the v2.8.0 broadcast_on_channel had.
+     * A broadcast_targets entry that sets no channel_index transmits on this channel; an entry that
+     * sets one overrides it. With neither set a target uses the node's primary channel, which is
+     * the meaning the v2.8.0 broadcast_on_channel had.
      */
     ChannelIdentity broadcast_on_channel = 8;
 
-    /*
-     * Region for the explicit target. UNSET means the running config region.
-     */
-    Config.LoRaConfig.RegionCode broadcast_on_region = 9;
-
-    /*
-     * Modem preset for the explicit target. Unset means the running config preset.
-     */
-    optional Config.LoRaConfig.ModemPreset broadcast_on_preset = 10;
+    // Tags 9 and 10 were broadcast_on_region and broadcast_on_preset, the region and preset of a
+    // single explicit target. Every target now states its own in BroadcastTarget, so both are
+    // reserved again, as they are in the last release.
+    reserved 9, 10;
+    reserved "broadcast_on_region", "broadcast_on_preset";
 
     /*
      * How often to broadcast, in seconds. Min 3600 (1 h), default 3600.
      */
     uint32 broadcast_interval_secs = 11;
 
-    /*
-     * Frequency slot for the explicit target, 1-based, matching Config.LoRaConfig.channel_num.
-     * Unset means derive it the way any node on that channel would. Do not send 0.
-     */
-    optional uint32 broadcast_on_frequency_slot = 12;
-
+    // Tag 12 is free. It briefly held the offer's channel-table index, then the explicit target's
+    // frequency slot; neither reached a release and BroadcastTarget.frequency_slot replaced the
+    // second, so the tag is left available rather than reserved.
 
     /*
      * One entry in the broadcast destination list.
@@ -981,8 +972,11 @@ message ModuleConfig {
        * Index into the device's channel table (0..MAX_NUM_CHANNELS-1) of the channel to
        * transmit this target's beacon on. The referenced channel must already be configured
        * on the node (its key is needed to encrypt) and must NOT be Role_DISABLED - a disabled
-       * slot retains the settings of a deleted channel. If unset, the default channel for the
-       * preset is used.
+       * slot retains the settings of a deleted channel.
+       * Unset falls back to broadcast_on_channel, the by-value default, and to the node's primary
+       * channel when that is unset too. A client that can read the channel table sets this; one
+       * that cannot - it has no remote channel query - sets broadcast_on_channel and leaves this
+       * blank. The firmware never fills it in, so a read back returns what was written.
        */
       optional uint32 channel_index = 4;
 
@@ -1000,11 +994,11 @@ message ModuleConfig {
     }
 
     /*
-     * Broadcast destination list.
+     * Broadcast destination list, and the only way to name a destination.
      * The broadcaster sends one beacon copy per distinct destination, in sequence, temporarily
      * switching the radio to that entry's preset/region/channel for each.
-     * When empty, a single beacon is sent on the node's running preset and region over the
-     * primary channel.
+     * When empty, a single beacon is sent on the node's running preset and region, over
+     * broadcast_on_channel if that is set and the primary channel otherwise.
      * Entries that resolve to the same effective preset, region and channel are deduplicated, so
      * a duplicate entry does not produce a second transmission.
      */

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -912,6 +912,8 @@ message ModuleConfig {
      * remote administrator cannot read the channel table and so cannot know what an index
      * resolves to. Upserted into the channel table on write: matched by name and PSK, else
      * placed in a disabled slot, else the offer is withheld. Never overwrites a live channel.
+     * A withheld offer clears broadcast_offer_region, _preset and _frequency_slot with it, so a
+     * read back returns no offer rather than one naming a channel this node does not hold.
      * ChannelIdentity is a wire-compatible subset of the ChannelSettings this tag carried in
      * v2.8.0, so a v2.8.0 client's write still decodes correctly here.
      */
@@ -930,10 +932,14 @@ message ModuleConfig {
     /*
      * Default channel for the broadcast targets, named by value. This is the remote-administration
      * path: an administrator that cannot read the channel table states the channel outright.
-     * Upserted into the channel table exactly as broadcast_offer_channel is.
+     * Upserted into the channel table as broadcast_offer_channel is, but kept when the table is
+     * full: the entries inheriting it are skipped for want of a key, never redirected elsewhere.
      * A broadcast_targets entry that sets no channel_index transmits on this channel; an entry that
      * sets one overrides it. With neither set a target uses the node's primary channel, which is
      * the meaning the v2.8.0 broadcast_on_channel had.
+     * Naming this and broadcast_offer_channel by value on 32-byte keys can put the config past what
+     * one PKC-encrypted frame carries; such a write is refused TOO_LARGE from a remote administrator
+     * and warned about, but stored, from a local client.
      */
     ChannelIdentity broadcast_on_channel = 8;
 

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package meshtastic;
 
 import "meshtastic/atak.proto";
-import "meshtastic/channel.proto";
 import "meshtastic/config.proto";
 
 option csharp_namespace = "Meshtastic.Protobufs";
@@ -899,10 +898,18 @@ message ModuleConfig {
      */
     string broadcast_message = 4;
 
+    // Tag 5 was broadcast_offer_channel, an inline ChannelSettings. Replaced by
+    // broadcast_offer_channel_index (tag 12): one entry point for channel data, and the
+    // admin message no longer carries a second copy of a name and PSK.
+    reserved 5;
+    reserved "broadcast_offer_channel";
+
     /*
-     * Optional channel (name + PSK) to advertise in the MeshBeacon offer_channel field.
+     * Index into the device's channel table of the channel to advertise. The slot must be
+     * configured and NOT Role_DISABLED - a disabled slot retains the settings of a deleted
+     * channel, and advertising it would broadcast a retired PSK.
      */
-    ChannelSettings broadcast_offer_channel = 5;
+    optional uint32 broadcast_offer_channel_index = 12;
 
     /*
      * Optional region to advertise in the MeshBeacon offer_region field.
@@ -928,6 +935,7 @@ message ModuleConfig {
      */
     uint32 broadcast_interval_secs = 11;
 
+
     /*
      * One entry in the broadcast destination list.
      * Each entry names one set of radio settings to send a beacon copy on.
@@ -944,16 +952,29 @@ message ModuleConfig {
        */
       Config.LoRaConfig.RegionCode region = 2;
 
-      // Tag 3 was an embedded ChannelSettings; replaced by channel_index (tag 4) to keep
-      // ModuleConfig within the BLE FromRadio size budget. Branch unreleased, so tag 3 is a gap.
+      // Tag 3 was an embedded ChannelSettings; replaced by channel_index (tag 4).
+      reserved 3;
 
       /*
        * Index into the device's channel table (0..MAX_NUM_CHANNELS-1) of the channel to
        * transmit this target's beacon on. The referenced channel must already be configured
-       * on the node (its key is needed to encrypt). If unset, the default channel for the
+       * on the node (its key is needed to encrypt) and must NOT be Role_DISABLED - a disabled
+       * slot retains the settings of a deleted channel. If unset, the default channel for the
        * preset is used.
        */
       optional uint32 channel_index = 4;
+
+      /*
+       * Frequency slot to transmit this target's beacon on, 1-based, matching
+       * Config.LoRaConfig.channel_num. Unset means derive it the way any node on this
+       * channel would: the region's override slot if it has one, otherwise the hash of the
+       * target channel's name. Do not send 0 - it is the same as unset.
+       * Explicit modem parameters and a verbatim override frequency are deliberately not
+       * offered here; if they are added later this field becomes one arm of a oneof with
+       * override_frequency, which keeps the tag and wire format but changes the C API.
+       */
+      optional uint32 frequency_slot = 5;
+
     }
 
     /*
@@ -965,6 +986,14 @@ message ModuleConfig {
      * Entries that resolve to the same effective preset, region and channel are deduplicated, so
      * a duplicate entry does not produce a second transmission.
      */
+    /*
+     * Frequency slot to advertise, 1-based, matching Config.LoRaConfig.channel_num.
+     * Unset means the receiver can derive it from the advertised region, channel name and
+     * preset - which covers a region that mandates a slot, and a mesh on the default hash.
+     * Set it only where the mesh deliberately pins a non-default slot. Do not send 0.
+     */
+    optional uint32 broadcast_offer_frequency_slot = 14;
+
     repeated BroadcastTarget broadcast_targets = 13;
   }
 

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package meshtastic;
 
 import "meshtastic/atak.proto";
+import "meshtastic/channel.proto";
 import "meshtastic/config.proto";
 
 option csharp_namespace = "Meshtastic.Protobufs";
@@ -886,6 +887,14 @@ message ModuleConfig {
      */
     uint32 flags = 1;
 
+    /*
+     * Frequency slot to advertise, 1-based, matching Config.LoRaConfig.channel_num.
+     * Unset means the receiver derives it from the advertised region, channel name and preset,
+     * which covers a region that mandates a slot and a mesh on the default hash. Set it only
+     * where the mesh deliberately pins a non-default slot. Do not send 0.
+     */
+    optional uint32 broadcast_offer_frequency_slot = 2;
+
     // Tag 3 was broadcast_send_as_node, a node-ID override that rewrote the `from` field of
     // outgoing beacon packets so they appeared to originate from another node. Firmware never
     // applied it (the assignment was left commented out) and it never reached a tagged release,
@@ -898,42 +907,58 @@ message ModuleConfig {
      */
     string broadcast_message = 4;
 
-    // Tag 5 was broadcast_offer_channel, an inline ChannelSettings. Replaced by
-    // broadcast_offer_channel_index (tag 12): one entry point for channel data, and the
-    // admin message no longer carries a second copy of a name and PSK.
-    reserved 5;
-    reserved "broadcast_offer_channel";
-
     /*
-     * Index into the device's channel table of the channel to advertise. The slot must be
-     * configured and NOT Role_DISABLED - a disabled slot retains the settings of a deleted
-     * channel, and advertising it would broadcast a retired PSK.
+     * Channel to advertise, by value. Named explicitly rather than by table index because a
+     * remote administrator cannot read the channel table and so cannot know what an index
+     * resolves to. Upserted into the channel table on write: matched by name and PSK, else
+     * placed in a disabled slot, else the offer is withheld. Never overwrites a live channel.
+     * ChannelIdentity is a wire-compatible subset of the ChannelSettings this tag carried in
+     * v2.8.0, so a v2.8.0 client's write still decodes correctly here.
      */
-    optional uint32 broadcast_offer_channel_index = 12;
+    ChannelIdentity broadcast_offer_channel = 5;
 
     /*
      * Optional region to advertise in the MeshBeacon offer_region field.
      */
-    Config.LoRaConfig.RegionCode broadcast_offer_region = 6;
+    optional Config.LoRaConfig.RegionCode broadcast_offer_region = 6;
 
     /*
      * Optional modem preset to advertise in the MeshBeacon offer_preset field.
      */
     optional Config.LoRaConfig.ModemPreset broadcast_offer_preset = 7;
 
-    // Tags 8, 9 and 10 were broadcast_on_channel / broadcast_on_region / broadcast_on_preset: a
-    // second way to describe a single beacon destination, used only when broadcast_targets was
-    // empty. Consolidated onto broadcast_targets so there is one way to name a destination.
-    // broadcast_on_channel embedded a ChannelSettings inline, which allowed transmitting on a
-    // channel absent from the node's channel table; that is no longer supported - the channel must
-    // exist on the node. Never in a tagged release. Reserved to prevent reuse.
-    reserved 8, 9, 10;
-    reserved "broadcast_on_channel", "broadcast_on_region", "broadcast_on_preset";
+    /*
+     * The single explicit broadcast target, named by value. This is the remote-administration
+     * path: an administrator that cannot read the channel table states the channel outright.
+     * Upserted into the channel table exactly as broadcast_offer_channel is.
+     * Mutually exclusive with broadcast_targets (tag 13), which is the local-administration path.
+     * If both arrive in one message the indexed list wins and these fields are cleared, because
+     * an index cannot mutate the channel table and a by-value entry can.
+     * Unset while broadcast_on_region / _preset / _frequency_slot are set means the node's
+     * primary channel, retuned - the same meaning the v2.8.0 broadcast_on_channel had.
+     */
+    ChannelIdentity broadcast_on_channel = 8;
+
+    /*
+     * Region for the explicit target. UNSET means the running config region.
+     */
+    optional Config.LoRaConfig.RegionCode broadcast_on_region = 9;
+
+    /*
+     * Modem preset for the explicit target. Unset means the running config preset.
+     */
+    optional Config.LoRaConfig.ModemPreset broadcast_on_preset = 10;
 
     /*
      * How often to broadcast, in seconds. Min 3600 (1 h), default 3600.
      */
     uint32 broadcast_interval_secs = 11;
+
+    /*
+     * Frequency slot for the explicit target, 1-based, matching Config.LoRaConfig.channel_num.
+     * Unset means derive it the way any node on that channel would. Do not send 0.
+     */
+    optional uint32 broadcast_on_frequency_slot = 12;
 
 
     /*
@@ -948,12 +973,9 @@ message ModuleConfig {
       optional Config.LoRaConfig.ModemPreset preset = 1;
 
       /*
-       * Region to use for this target. UNSET means use the running config region.
+       * Region to use for this target. Unset means use the running config region.
        */
-      Config.LoRaConfig.RegionCode region = 2;
-
-      // Tag 3 was an embedded ChannelSettings; replaced by channel_index (tag 4).
-      reserved 3;
+      optional Config.LoRaConfig.RegionCode region = 2;
 
       /*
        * Index into the device's channel table (0..MAX_NUM_CHANNELS-1) of the channel to
@@ -986,14 +1008,6 @@ message ModuleConfig {
      * Entries that resolve to the same effective preset, region and channel are deduplicated, so
      * a duplicate entry does not produce a second transmission.
      */
-    /*
-     * Frequency slot to advertise, 1-based, matching Config.LoRaConfig.channel_num.
-     * Unset means the receiver can derive it from the advertised region, channel name and
-     * preset - which covers a region that mandates a slot, and a mesh on the default hash.
-     * Set it only where the mesh deliberately pins a non-default slot. Do not send 0.
-     */
-    optional uint32 broadcast_offer_frequency_slot = 14;
-
     repeated BroadcastTarget broadcast_targets = 13;
   }
 

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -920,7 +920,7 @@ message ModuleConfig {
     /*
      * Optional region to advertise in the MeshBeacon offer_region field.
      */
-    optional Config.LoRaConfig.RegionCode broadcast_offer_region = 6;
+    Config.LoRaConfig.RegionCode broadcast_offer_region = 6;
 
     /*
      * Optional modem preset to advertise in the MeshBeacon offer_preset field.
@@ -942,7 +942,7 @@ message ModuleConfig {
     /*
      * Region for the explicit target. UNSET means the running config region.
      */
-    optional Config.LoRaConfig.RegionCode broadcast_on_region = 9;
+    Config.LoRaConfig.RegionCode broadcast_on_region = 9;
 
     /*
      * Modem preset for the explicit target. Unset means the running config preset.
@@ -973,9 +973,9 @@ message ModuleConfig {
       optional Config.LoRaConfig.ModemPreset preset = 1;
 
       /*
-       * Region to use for this target. Unset means use the running config region.
+       * Region to use for this target. UNSET means use the running config region.
        */
-      optional Config.LoRaConfig.RegionCode region = 2;
+      Config.LoRaConfig.RegionCode region = 2;
 
       /*
        * Index into the device's channel table (0..MAX_NUM_CHANNELS-1) of the channel to


### PR DESCRIPTION
A broadcast target and the advertised offer can only describe the frequency slot they use by implication, through the hash of a channel name. A mesh that pins a slot cannot describe itself: `channel_num == 0` means "derive from `hash(channel_name)`", so advertising a name whose hash resolves elsewhere advertises the wrong frequency (#11516). This adds `frequency_slot` to `BroadcastTarget`, `broadcast_offer_frequency_slot` to `MeshBeaconConfig`, and `offer_frequency_slot` to the on-air `MeshBeacon`. All are 1-based to match `Config.LoRaConfig.channel_num`; unset means derive, and 0 must not be sent.

`offer_frequency_slot` is populated only when a receiver could not derive the same slot itself from the offered region, channel name and preset, so a mesh on a derivable slot spends no bytes on it.

## By value, not by index

An earlier revision moved the offer channel to `broadcast_offer_channel_index`, a slot in the device's channel table. That is wrong for the case it has to serve. A client with no remote channel query — the iOS app is the one in practice — cannot resolve an index on another node, so an admin message has to carry the channel outright.

Tag 5 therefore stays a channel, and a new `ChannelIdentity` carries it:

```proto
message ChannelIdentity {
  bytes psk = 2;
  string name = 3;
}
```

The tag numbers deliberately match `ChannelSettings`, so the two are wire compatible in both directions: a `ChannelSettings` decodes as a `ChannelIdentity` with the remaining fields skipped as unknown, and a `ChannelIdentity` decodes as a `ChannelSettings` with only those two set. The fields left out — `id`, `uplink_enabled`, `downlink_enabled`, `module_settings` — describe the advertising node's own posture and have no business travelling with a channel someone else is being invited to join. At 47 bytes against `ChannelSettings`' 72, this is also what pays for the new fields.

## One list of destinations

An earlier revision put a second, config-level destination on tags 8, 9, 10 and 12, mutually exclusive with `broadcast_targets`. Its region, preset and slot duplicated `BroadcastTarget`'s own tags 2, 1 and 5, which meant an arbitration rule between the two spellings and, in the firmware, a synthetic `BroadcastTarget` assembled to feed the one loop that resolves a destination.

`broadcast_targets` (tag 13) is now the only way to name a destination. Tags 9 and 10 return to the reserved set they occupy on master. Tag 12 never reached a release and is left free rather than reserved.

`broadcast_on_channel` (tag 8) stays, repurposed from "the single explicit target" to the by-value **default** that entries inherit:

| entry | resolves to |
| --- | --- |
| sets `channel_index` | that channel-table slot |
| sets no `channel_index`, `broadcast_on_channel` set | the by-value channel, upserted into the table on write |
| neither | the node's primary channel |

A client that cannot enumerate the channel table writes the identity once and leaves every index blank. One that can, writes indices. The firmware never fills an index in, so a read back returns what was written. The two are no longer exclusive: a config may pin some destinations by index and let the rest inherit.

An empty list still beacons once, on the node's running preset and region, over the default channel if one is named.

`ModuleConfig` drops from 308 to 258 bytes. On the air, `MeshBeacon` drops from 186 to 121.

## Length is checked at both ends

Remote admin is PKC encrypted, so an admin message gets `MAX_LORA_PAYLOAD_LEN` 255, less the 16-byte header, less 12 bytes of PKC overhead, less 6 bytes of `Data` framing: **221 bytes**, not the 233 of `DATA_PAYLOAD_LEN`, which is the *decoded* cap and is what a local BLE client gets.

Two gates enforce it, at opposite ends of the exchange:

- **Before the packet goes out.** The administering node's router refuses to transmit a PKC packet whose payload plus header plus PKC overhead exceeds 255, returning `Routing.Error TOO_LARGE` to the phone client that asked for it. Generic, not beacon-specific — it protects the request.
- **On the node being administered.** The beacon module measures the sanitised config and refuses a remote write it could never send back, again `TOO_LARGE`, routed back across the mesh to the administering client. This protects the future read-back, which the sender has no way to size. It bites where the request arrived over a path with more headroom than PKC — the legacy admin channel is channel-encrypted, so it has the full 233 — and the response would not fit.

Either way the client is told why. Nothing is silently truncated, and nothing is stored that could not later be shown back.

Measured encodings of a `set_module_config`, session passkey included, with the message at its 60-byte maximum:

| Config | Bytes |
| --- | --- |
| Offer by value, four destinations by index | 181 |
| Offer and default channel both by value, 32-byte PSKs, four destinations | 230 |

The second is over 221 and under 233: an ordinary configuration — a private mesh advertised to private destinations — that a local client can write and a remote one cannot. It is not a misconfiguration, and the firmware refuses it only for remote writes.

`broadcast_message` is capped at 60 bytes (`max_size:61`; nanopb counts the NUL) to keep the common shapes clear of the bound.

## Notes for reviewers

**`buf breaking` will flag this.** `buf.yaml` sets `breaking.use: [FILE]`, whose `FIELD_NO_DELETE` is not satisfied by a `reserved` statement — only the `WIRE`/`WIRE_JSON` variants are. v2.8.0 is tagged and contains 369550b, so `MeshBeaconConfig` on master is released and the "never shipped" argument used on #1047 and #1048 no longer applies. Two things here need the stronger argument:

- **Tag 5 changes type**, `ChannelSettings` to `ChannelIdentity`, and so does `MeshBeacon.offer_channel`. Wire compatible in both directions by construction, so no encoded data becomes unreadable. It is still a generated-API break: the field's type changes in the Kotlin, TS and Python output.
- **Tag 8 is un-reserved and reused**, under the name it was reserved with. v2.8.0 reserved it without ever populating it, so no encoded data exists at that number. It carries a `ChannelIdentity` where the pre-2.8.0 development branch had a `ChannelSettings` — the same wire-compatible pair as tag 5.

Returning tags 9 and 10 to `reserved` removes four of the eight errors the previous revision produced.

**A firmware change must land with the submodule bump.** `AdminModule.cpp` and `MeshBeaconModule.cpp` read these fields directly, so bumping the submodule without meshtastic/firmware#11662 will not compile.

Firmware side: meshtastic/firmware#11662.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added channel identity support for mesh beacon offers.
  * Added configurable frequency slots for beacon offers and broadcast targets.
  * Added Codec2 audio modes with 700C and 450 bitrate options.
* **Improvements**
  * Mesh beacon messages now support up to 60 bytes.
  * Channel identity fields now enforce appropriate name and key limits.
* **Deprecations**
  * Deprecated the Codec2 700 and 700B audio modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->