### PR TITLE
fix(ts): repair the npm build under TypeScript 7

### DIFF
--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -19,7 +19,7 @@
     "@bufbuild/protobuf": "^2.2.3"
   },
   "devDependencies": {
-    "tsdown": "^0.13.4",
+    "tsdown": "^0.22.14",
     "typescript": "^7.0.0"
   },
   "scripts": {
@@ -31,6 +31,7 @@
     "format": [
       "esm"
     ],
-    "splitting": false
+    "splitting": false,
+    "fixedExtension": false
   }
 }

--- a/packages/ts/tsconfig.json
+++ b/packages/ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["mod.ts", "lib/**/*.ts"]
+}


### PR DESCRIPTION
## Problem

The [v2.8.0 publish run](https://github.com/meshtastic/protobufs/actions/runs/33310294482) failed in `build-typescript`. Root cause is #1008, which bumped `typescript` to `^7.0.0` without touching `tsdown`. Three distinct problems fell out of that:

**1. `npm install` died with `ERESOLVE`**

```
npm error While resolving: tsdown@0.13.5
npm error Found: typescript@7.0.2
npm error Could not resolve dependency:
npm error peerOptional typescript@"^5.0.0" from tsdown@0.13.5
```

`tsdown@0.13.5` and its `rolldown-plugin-dts@0.15.10` declare `peerDependencies.typescript: "^5.0.0"`, which `typescript@7.0.2` cannot satisfy. There is no `package-lock.json` in `packages/ts`, so every CI run resolves fresh — nothing pinned this to a working tree, and a manifest-only Renovate bump was enough to break publishing. `tsdown@0.22.14` widens the range to `^5.0.0 || ^6.0.0 || ^7.0.0`.

**2. tsgo requires a tsconfig**

TypeScript 7 is tsgo-based, so `rolldown-plugin-dts` selects the tsgo generator, which fails with `tsgo generator requires a tsconfig file to be specified`. `packages/ts` had none — TS 5 plus tsdown 0.13 never needed one. Added a minimal `tsconfig.json`; it reaches CI automatically, since the `ts_code` artifact uploads all of `packages/ts`.

**3. tsdown 0.22 changed the default output extensions**

It emits `dist/mod.mjs` and `dist/mod.d.mts`, while `package.json` advertises `./dist/mod.js` and `./dist/mod.d.ts`. That builds green but publishes a package whose entry points do not resolve, so this pins `fixedExtension: false`.

## Bonus fix

`@meshtastic/protobufs@2.7.26` on npm ships `dist/mod-toAbfzRb.d.ts` while its `types` field points at `./dist/mod.d.ts`, so **type resolution is broken for consumers today**. The dts is now emitted as `dist/mod.d.ts`, matching the manifest.

## Verification

Replicated the CI pipeline locally — `buf generate`, move `lib/meshtastic/*_pb.ts` to `lib/`, substitute the version, `npm install`, `npm run build`:

- `npm install` resolves clean, no ERESOLVE, 0 vulnerabilities
- build succeeds, emitting `dist/mod.js` (354 kB) and `dist/mod.d.ts` (481 kB)
- all three of `main` / `module` / `types` resolve to files that exist
- packed the tarball, installed it into a scratch consumer: all 20 namespaces export, and a `Mesh.Data` protobuf encode/decode round-trips
- a consumer typechecks against the emitted `.d.ts` with `skipLibCheck: false` — clean

## Note

tsdown now warns `TypeScript 7.0 does not yet have a stable API and is experimental. Some options will be unavailable.` Output is correct, but that is the tradeoff of staying on TS 7 rather than reverting #1008.

## Follow-up

`push-buf-registry` already succeeded on the failed run, so v2.8.0 is on the Buf registry. npm, JSR, and the release assets are still outstanding and will need a re-dispatch once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TypeScript build tooling.
  * Refined build output settings for improved compatibility.
  * Added stricter TypeScript project configuration and declaration generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->