### PR TITLE
Reserve PAGING_APP for acknowledged paging

### DIFF
--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -164,6 +164,15 @@ enum PortNum {
   MESH_BEACON_APP = 37;
 
   /*
+   * Acknowledged paging: alerts a person is expected to physically acknowledge, and the
+   * acknowledgements themselves.
+   * ENCODING: protobuf PagingPacket
+   * Distinct from ALERT_APP, which is a text message the recipient never confirms, and from a
+   * routing or delivery ACK, which says the packet arrived rather than that someone saw it.
+   */
+  PAGING_APP = 38;
+
+  /*
    * Provides a hardware serial interface to send and receive from the Meshtastic network.
    * Connect to the RX/TX pins of a device with 38400 8N1. Packets received from the Meshtastic
    * network is forwarded to the RX pin while sending a packet to TX will go out to the Mesh network.


### PR DESCRIPTION
Alerts that a person is expected to physically acknowledge, and the acknowledgements themselves, need a portnum of their own: `ALERT_APP` is a text message the recipient never confirms, and a routing or delivery ACK asserts that the packet arrived rather than that a human saw and dismissed it, which is the whole point of carrying a pager instead of a phone. This reserves the number only, so nothing changes for any existing client; the `PagingPacket` / `Page` / `PageAck` messages ride with the firmware module that implements it, and can move here once that module has been reviewed. 38 is the next free number after `MESH_BEACON_APP = 37`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a dedicated paging message type.
  * Paging acknowledgements can now be distinguished from text alerts and packet-delivery acknowledgements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->