### PR TITLE
Deprecate the Range Test module config, admin type and portnum

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -109,9 +109,9 @@ message AdminMessage {
     STOREFORWARD_CONFIG = 3;
 
     /*
-     * TODO: REPLACE
+     * Deprecated in 2.8: the Range Test module is compiled out of every firmware target.
      */
-    RANGETEST_CONFIG = 4;
+    RANGETEST_CONFIG = 4 [deprecated = true];
 
     /*
      * TODO: REPLACE

--- a/meshtastic/localonly.proto
+++ b/meshtastic/localonly.proto
@@ -88,8 +88,9 @@ message LocalModuleConfig {
 
   /*
    * The part of the config that is specific to the RangeTest module
+   * Deprecated in 2.8: the Range Test module is compiled out of every firmware target.
    */
-  ModuleConfig.RangeTestConfig range_test = 5;
+  ModuleConfig.RangeTestConfig range_test = 5 [deprecated = true];
 
   /*
    * The part of the config that is specific to the Telemetry module

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2914,6 +2914,7 @@ enum ExcludedModules {
 
   /*
    * Range Test module
+   * Always set by firmware 2.8 and later, where the module is compiled out of every target; clients hide the config when it is set.
    */
   RANGETEST_CONFIG = 0x0010;
 

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -566,8 +566,11 @@ message ModuleConfig {
 
   /*
    * Preferences for the RangeTestModule
+   * Deprecated in 2.8: the Range Test module is compiled out of every firmware target and no longer acts on this config.
    */
   message RangeTestConfig {
+    option deprecated = true;
+
     /*
      * Enable the Range Test Module
      */
@@ -974,9 +977,9 @@ message ModuleConfig {
     StoreForwardConfig store_forward = 4;
 
     /*
-     * TODO: REPLACE
+     * Deprecated in 2.8: the Range Test module is compiled out of every firmware target.
      */
-    RangeTestConfig range_test = 5;
+    RangeTestConfig range_test = 5 [deprecated = true];
 
     /*
      * TODO: REPLACE

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -193,8 +193,9 @@ enum PortNum {
    * Optional port for messages for the range test module.
    * ENCODING: ASCII Plaintext
    * NOTE: This portnum traffic is not sent to the public MQTT starting at firmware version 2.2.9
+   * Deprecated in 2.8: the Range Test module is compiled out of every firmware target, so nothing emits this portnum.
    */
-  RANGE_TEST_APP = 66;
+  RANGE_TEST_APP = 66 [deprecated = true];
 
   /*
    * Provides a format to send and receive telemetry data from the Meshtastic network.


### PR DESCRIPTION
## Summary

Firmware 2.8 compiles the Range Test module out of every target ([meshtastic/firmware#11150](https://github.com/meshtastic/firmware/pull/11150), shipped in [2.8.0.47db0e3 Alpha](https://github.com/meshtastic/firmware/releases/tag/v2.8.0.47db0e3)). Nothing acts on `RangeTestConfig` any more, and nothing emits `RANGE_TEST_APP`. This marks the protocol surface deprecated so generated code and clients get the signal.

## Deprecated

- `ModuleConfig.RangeTestConfig` (message-level `option deprecated = true`)
- `ModuleConfig.range_test`
- `LocalModuleConfig.range_test`
- `AdminMessage.ModuleConfigType.RANGETEST_CONFIG`
- `PortNum.RANGE_TEST_APP`

Each carries the repo's usual `Deprecated in 2.8: ...` comment. Field numbers and enum values are unchanged, so stored configs and older firmware still decode.

## Intentionally kept

`ExcludedModules.RANGETEST_CONFIG` is not deprecated. Firmware 2.8+ sets it unconditionally in the device metadata and clients rely on it to hide the module's settings; its comment now says so.

## Verification

`protoc` (libprotoc 35.1) parses all five edited files. Annotations only, so `buf breaking` should be clean; no wire-format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Marked Range Test configuration fields, messages, and application identifiers as deprecated.
  * Clarified that Range Test is compiled out of firmware targets starting with version 2.8.
  * Clients should hide Range Test configuration and should not expect firmware to emit Range Test messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->