### PR TITLE
Beacon config cleanup: frequency slots and a shorter beacon message

### DIFF
--- a/meshtastic/mesh_beacon.options
+++ b/meshtastic/mesh_beacon.options
@@ -1,3 +1,3 @@
-*MeshBeacon.message max_size:101
+*MeshBeacon.message max_size:61
 *MeshBeacon.offer_channel.name max_size:12
 *MeshBeacon.offer_channel.psk max_size:32

--- a/meshtastic/mesh_beacon.proto
+++ b/meshtastic/mesh_beacon.proto
@@ -39,4 +39,15 @@ message MeshBeacon {
    * Combined with offer_region, tells a client "there is a mesh on this preset/region".
    */
   optional Config.LoRaConfig.ModemPreset offer_preset = 4;
+
+  /*
+   * Frequency slot this mesh uses, 1-based, matching Config.LoRaConfig.channel_num.
+   * OMITTED when a receiver can derive the slot itself from offer_region, offer_channel's
+   * name and offer_preset - an unset offer_preset means the region's default preset. That
+   * covers both a region with a mandated slot and a mesh on the default name hash.
+   * PRESENT means this mesh deliberately deviates from what derivation would produce; a
+   * client should still validate the result against its own region before offering to join.
+   * Do not send 0 - it is the same as omitting the field.
+   */
+  optional uint32 offer_frequency_slot = 5;
 }

--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -30,7 +30,7 @@
 
 *StatusMessageConfig.node_status max_size:80
 
-*MeshBeaconConfig.broadcast_message max_size:101
+*MeshBeaconConfig.broadcast_message max_size:61
 *MeshBeaconConfig.broadcast_offer_channel.name max_size:12
 *MeshBeaconConfig.broadcast_offer_channel.psk max_size:32
 *MeshBeaconConfig.broadcast_targets max_count:4

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -868,6 +868,14 @@ message ModuleConfig {
      */
     uint32 flags = 1;
 
+    /*
+     * Frequency slot to advertise, 1-based, matching Config.LoRaConfig.channel_num.
+     * Unset means the receiver derives it from the advertised region, channel name and
+     * preset, which covers a region that mandates a slot and a mesh on the default hash.
+     * Set it only where the mesh deliberately pins a non-default slot. Do not send 0.
+     */
+    optional uint32 broadcast_offer_frequency_slot = 2;
+
     // Tag 3 was broadcast_send_as_node, a node-ID override that rewrote the `from` field of
     // outgoing beacon packets so they appeared to originate from another node. Firmware never
     // applied it (the assignment was left commented out) and it never reached a tagged release,
@@ -876,7 +884,11 @@ message ModuleConfig {
     reserved "broadcast_send_as_node";
 
     /*
-     * Message to include in each beacon broadcast. Max 100 bytes enforced by firmware.
+     * Message to include in each beacon broadcast.
+     * Every beacon copy carries this on the air, so it is the largest single cost in both
+     * this config and the packet it produces. Held to 60 bytes for that reason. The nanopb
+     * max_size is 61 because it counts the terminator, which is what leaves a client a
+     * round 60.
      */
     string broadcast_message = 4;
 
@@ -935,6 +947,14 @@ message ModuleConfig {
        * preset is used.
        */
       optional uint32 channel_index = 4;
+
+      /*
+       * Frequency slot to transmit this target's beacon on, 1-based, matching
+       * Config.LoRaConfig.channel_num. Unset means derive it the way any node on this
+       * channel would: the region's override slot if it has one, otherwise the hash of the
+       * target channel's name. Do not send 0 - it is the same as unset.
+       */
+      optional uint32 frequency_slot = 5;
     }
 
     /*


### PR DESCRIPTION
## Summary

A mesh that pins a frequency slot has no way to say so. `channel_num == 0`
means derive from `hash(channel_name)`, so a mesh that advertises a name whose
hash resolves to a different slot advertises the wrong frequency, and a client
that joins hears nothing.

The beacon message is also the largest single thing in both the config and the
packet it produces. At 100 bytes a full config with four targets does not fit
under 200.

## What changed

Three frequency slot fields, all 1-based to match
`Config.LoRaConfig.channel_num`. Unset means derive it; 0 is not sent.

- `MeshBeacon.offer_frequency_slot` (tag 5). Only populated when a receiver
  could not derive the same slot from the offered region, name and preset, so
  a mesh on a derivable slot spends no bytes on it.
- `MeshBeaconConfig.broadcast_offer_frequency_slot` (tag 2)
- `MeshBeaconConfig.BroadcastTarget.frequency_slot` (tag 5)

The beacon message drops from 100 to 60 bytes, in both
`MeshBeaconConfig.broadcast_message` and `MeshBeacon.message`. They are the
same string, so cutting only the config would leave it truncating on the air.
The `max_size` option is 61 because nanopb counts the terminator, which is what
leaves a client a round 60.

## Testing

Encoded a `set_module_config` on this branch with `protoc`: 8-byte session
passkey, 12-character channel name, region, preset and frequency slot on the
offer, and all four `broadcast_targets` with region, preset, channel index and
slot.

| Offer channel key | Before | After |
| --- | --- | --- |
| Well-known default (1 byte) | 191 | 151 |
| AES128 (16 bytes) | 206 | 166 |
| AES256 (32 bytes) | 222 | 182 |

The largest config that can be expressed is now 182 bytes. Before this the two
larger key sizes did not fit under 200. Each target costs 10 bytes; the byte
budget would allow 8, 7 and 5 of them at those key sizes, so `max_count:4`
binds first.

Empty keys are left out of the table. An unencrypted channel is for licensed
operation only.

200 is a target with margin. The hard limit is about 221 bytes, because remote
admin is always PKC encrypted: 255 `MAX_LORA_PAYLOAD_LEN`, less 16 for the
packet header, less 12 for `MESHTASTIC_PKC_OVERHEAD`, less the `Data` framing.
`DATA_PAYLOAD_LEN` 233 is the decoded cap, not what survives encryption, and
the BLE budget does not apply because admin messages cross LoRa. A remote admin
write is unicast with `want_ack` and retries, so a packet near the ceiling is a
long transmission with a poor chance of being acknowledged.