### PR TITLE
Add NodeInfo.heard_on_current_lora

### DIFF
--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -154,6 +154,8 @@ message NodeInfoLite {
 
   /*
    * Bitfield for storing booleans. See NODEINFO_BITFIELD_* in src/mesh/NodeDB.h.
+   * Bit 11 is NODEINFO_BITFIELD_HEARD_ON_CURRENT_LORA, mirrored on the wire as
+   * NodeInfo.heard_on_current_lora.
    */
   uint32 bitfield = 13;
 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2076,6 +2076,18 @@ message NodeInfo {
    * LSB 1 of the bitfield
    */
   bool has_xeddsa_signed = 14;
+
+  /*
+   * True if we have heard this node over RF since our current LoRa
+   * configuration took effect. Cleared for every node whenever the region,
+   * modem preset (or the custom bandwidth/spread factor/coding rate when
+   * use_preset is false), override_frequency, channel_num or the primary
+   * channel name changes - the frequency slot is derived from that name.
+   * Not set for nodes heard over MQTT, which reach us over the internet
+   * rather than over our own radio - see via_mqtt.
+   * LSB 11 of the bitfield
+   */
+  bool heard_on_current_lora = 15;
 }
 
 /*


### PR DESCRIPTION
Closes #1060. Spec: meshtastic/design#146

Changing region, modem preset, frequency slot or the custom radio parameters moves a radio to a different channel. The node DB does not move with it, so clients keep listing nodes that can no longer be reached, and sends into that list fail - silently for channel broadcasts, which carry no ack. Nothing on the wire says so today.

`NodeInfo.heard_on_current_lora` (field 15) is set once the device hears a node over RF under its current LoRa config, and cleared for every node when that config changes. Clients mark the unset ones.

## Why a bool and not a timestamp

The obvious alternative is a device-level "config changed at", with staleness derived as `last_heard < changed_at`. Firmware treats `last_heard` as a real epoch or zero, and routes nodes heard while the clock is untrusted into a sidecar for later backfill. A radio reconfigured before it has a time source records a zero watermark, and every pre-change node with a real timestamp then compares as fresh. A bool is clock-independent.

## Why not a per-node config id

That would let a client name the previous preset, but `NodeInfoLite` has been deliberately shrunk - positions and telemetry moved to satellite arrays, SNR packed to Q4, bools packed into `bitfield` - and the node cap is 120 on nRF52840 and generic ESP32. The device-side twin here is a spare bit in that existing bitfield (bits 0–10 are in use), so it costs no additional NodeDB bytes. Naming the previous preset stays possible later via a single device-level field.

## Notes

- Field 15 is new; nothing reused or removed. No nanopb annotation, so no firmware buffer resizing.
- Not set for MQTT hears - those reach the device over the internet rather than over its own radio, and `via_mqtt` already marks them.
- Proto3 bools default to false, so clients must gate on a firmware-version capability check rather than on the field alone. That requirement is carried in design#146.

## Testing

- `buf lint --path meshtastic` - clean.
- `buf breaking --against '.git#branch=master' --path meshtastic` - clean.

No consumer implements it yet. meshtastic/firmware#11745 is the reference implementation; meshtastic/Meshtastic-Apple#2429 has already shipped an interim app-side approximation that this field is intended to replace.
