### PR TITLE
Add T_CONNECT_PRO identifier to mesh.proto

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -964,6 +964,11 @@ enum HardwareModel {
   MESHPAGER_X2 = 146;
 
   /*
+   * Lilygo T-CONNECT PRO
+   */
+  T_CONNECT_PRO = 147;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying the Lilygo T-CONNECT PRO board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->