### PR TITLE
Add CODEC2_700C and CODEC2_450, deprecate 700 and 700B

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -232,8 +232,23 @@ message ModuleConfig {
       CODEC2_1400 = 4;
       CODEC2_1300 = 5;
       CODEC2_1200 = 6;
-      CODEC2_700 = 7;
-      CODEC2_700B = 8;
+
+      /*
+       * Removed from libcodec2 upstream. A device configured to one of these
+       * falls back to CODEC2_700C.
+       */
+      CODEC2_700 = 7 [deprecated = true];
+      CODEC2_700B = 8 [deprecated = true];
+
+      /*
+       * Replaces CODEC2_700. Default for new configurations.
+       */
+      CODEC2_700C = 9;
+
+      /*
+       * Lowest rate, and the only one usable on slower modem presets.
+       */
+      CODEC2_450 = 10;
     }
 
     /*
@@ -247,7 +262,7 @@ message ModuleConfig {
     uint32 ptt_pin = 2;
 
     /*
-     * The audio sample rate to use for codec2
+     * The codec2 bitrate to encode at. Sample rate is always 8 kHz.
      */
     Audio_Baud bitrate = 3;
 


### PR DESCRIPTION
libcodec2 removed modes 700 and 700B and renumbered what replaced them: 700C is mode 8 upstream, 450 is mode 10. The old enum stopped mapping to anything the current library implements, so a device configured for `CODEC2_700` selects a mode that no longer exists.

Adds `CODEC2_700C = 9` and `CODEC2_450 = 10`, and marks 7 and 8 deprecated rather than removing them, so stored configurations keep parsing. Firmware maps the enum to a codec2 mode id through a lookup table, so the numbering here no longer has to mirror the librarys, and values 7 and 8 resolve to 700C at runtime.

`450PWB` is deliberately absent. Its bitstream is byte identical to 450 and it shares the same encoder, differing only in decoding at 16 kHz. Encoding through a PWB instance is undefined behaviour upstream, so it does not belong in a field that selects what the transmitter encodes.

Also corrects the `bitrate` field comment: it selects a bitrate, not a sample rate, which is always 8 kHz.

Needed by the codec2 audio work in the firmware, which cannot express 700C or 450 without it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the CODEC2 700C bitrate option as the default for new audio configurations.
  * Added the lower-rate CODEC2 450 option for slower modem presets.
* **Changes**
  * Existing CODEC2 700 and 700B configurations are deprecated and will fall back to CODEC2 700C.
  * Clarified that the bitrate setting controls codec encoding rate, while audio remains sampled at 8 kHz.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->