### PR TITLE
Document zero-means-disabled semantics for TrafficManagementConfig

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -316,7 +316,10 @@ message ModuleConfig {
 
   /*
    * Config for the Traffic Management module.
-   * Provides packet inspection and traffic shaping to help reduce channel utilization
+   * Provides packet inspection and traffic shaping to help reduce channel utilization.
+   * Every field uses the proto3 zero value to mean "disabled"; there is no
+   * "use the firmware default" sentinel. Firmware installs its own defaults when it
+   * first creates this config, and a client that writes 0 turns that feature off.
    */
   message TrafficManagementConfig {
     // Tags 1, 2, 3, 5, 7, 10, 12, 13, 14 were bool toggle fields removed in favour
@@ -330,6 +333,7 @@ message ModuleConfig {
     /*
      * Minimum interval in seconds between position updates from the same node.
      * A non-zero value implicitly enables the suppression window; 0 disables it.
+     * Firmware default: 21600 (6 hours), installed when this config is first created.
      */
     uint32 position_min_interval_secs = 4;
 


### PR DESCRIPTION
# What does this PR do?

Documents the default-value contract on `ModuleConfig.TrafficManagementConfig`:

- Every field uses the proto3 zero value to mean "disabled". There is no "use the firmware default" sentinel, so a client that writes 0 to `position_min_interval_secs` turns position dedup off rather than restoring the default.
- The firmware default for `position_min_interval_secs` is 21600 (6 hours), installed only when the firmware first creates this config. Firmware change moving the default from 5 h to 6 h: meshtastic/firmware#11765.

Comment-only change; no wire format or field changes.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Traffic Management configuration behavior, including how zero values disable features.
  - Documented that firmware applies default settings when configuration is first created.
  - Added the default position suppression interval of 6 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->