### PR TITLE
feat(tmm): antispam trust-ladder wire format

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1583,6 +1583,28 @@ message StatusMessage {
 }
 
 /*
+ * Greylist gossip on ID_ATTESTATION_APP (80). One record per packet.
+ * Unsigned on mixed meshes; signed vouches are a later trust-ladder step.
+ */
+message IdAttestation {
+  enum Kind {
+    UNSPECIFIED = 0;
+    /* End a subject's probation window. */
+    KNOWN_SINCE = 1;
+    /* Stop relaying subject this window; still deliver locally. */
+    NO_RELAY = 2;
+  }
+
+  Kind kind = 1;
+  /* Node the record is about. 0 is ignored. */
+  uint32 subject = 2;
+  /* KNOWN_SINCE: last-heard truncated to the hour; 0 means no clock. */
+  uint32 known_since_secs = 3;
+  /* KNOWN_SINCE: attester uptime in seconds; 0 means no clock. */
+  uint32 attester_tenure_secs = 4;
+}
+
+/*
  * This message will be proxied over the PhoneAPI for the client to deliver to the MQTT server
  */
 message MqttClientProxyMessage {

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -358,6 +358,41 @@ message ModuleConfig {
      * 0 disables it.
      */
     uint32 unknown_packet_threshold = 11;
+
+    /* First-seen probation window in seconds. 0 disables. Default: 300. */
+    uint32 probation_window_secs = 15;
+    /* Self-reported attester uptime floor for KNOWN_SINCE. Default: 86400. */
+    uint32 attestation_min_tenure_secs = 16;
+    /* hop_limit on rebroadcasts from a node still in probation. Default: 2. */
+    uint32 probation_max_hop_limit = 17;
+    /* Honor neighbor top_senders as a rate-budget median. 0 disables. */
+    uint32 budget_gossip_enabled = 18;
+    /* Fresh IDs in one channel×RSSI cell that share a split budget. 0 disables. */
+    uint32 group_budget_enabled = 19;
+    /* Per-sender relayed-packet budget per window. 0 disables. Default: 0. */
+    uint32 relay_budget_max_packets = 20;
+    /* Channel-util percent that caps probation broadcasts at 1 hop. 0 disables. */
+    uint32 congestion_hop_cap_pct = 21;
+    /* Honor gossiped NO_RELAY only after local over-relay. Default: 1. */
+    uint32 no_relay_requires_local_exhaustion = 22;
+    /* Distinct NO_RELAY subjects one attester may mark per window. Default: 3. */
+    uint32 no_relay_max_subjects_per_window = 23;
+    /* Lifetime of one gossiped NO_RELAY claim in seconds. Default: 120. */
+    uint32 no_relay_ttl_secs = 24;
+    /* Locally observed attester age before a vouch is accepted. Default: 86400. */
+    uint32 attestation_min_observed_secs = 25;
+    /* Times per window one attester may vouch for one subject. Default: 1. */
+    uint32 vouch_max_per_subject_per_window = 26;
+    /* Distinct subjects one attester may vouch for per window. Default: 3. */
+    uint32 vouch_max_subjects_per_window = 27;
+    /* Distinct attesters required to end probation. Default: 2. */
+    uint32 attestation_min_distinct_attesters = 28;
+    /* Seconds a promotion lasts without a renewing vouch. 0 = permanent. */
+    uint32 attestation_promotion_ttl_secs = 29;
+    /* Observed attester age for a signed L2 upgrade. Default: 2592000. */
+    uint32 attestation_l2_min_tenure_secs = 30;
+    /* Distinct NO_RELAY claimers required (or local exhaustion). Default: 2. */
+    uint32 no_relay_min_claimers = 31;
   }
 
   /*

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -282,6 +282,12 @@ enum PortNum {
   LORA_OTA_APP = 79;
 
   /*
+   * ID attestation / greylist gossip. Carries IdAttestation: KNOWN_SINCE
+   * promotion or a gossiped NO_RELAY bit. ENCODING: nanopb IdAttestation.
+   */
+  ID_ATTESTATION_APP = 80;
+
+  /*
    * GroupAlarm integration
    * Used for transporting GroupAlarm-related messages between Meshtastic nodes
    * and companion applications/services.

--- a/meshtastic/telemetry.options
+++ b/meshtastic/telemetry.options
@@ -17,3 +17,5 @@
 *HostMetrics.load5 int_size:16
 *HostMetrics.load15 int_size:16
 *HostMetrics.user_string max_size:200
+
+*DeviceMetrics.top_senders max_count:3

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -9,6 +9,18 @@ option java_package = "org.meshtastic.proto";
 option swift_prefix = "";
 
 /*
+ * One of the top senders this rate window (DeviceMetrics.top_senders).
+ */
+message TopSender {
+  /* Sender node number. 0 is an unused slot. */
+  uint32 node = 1;
+  /* Packets observed this window. Saturates at 255. */
+  uint32 packets_this_window = 2;
+  /* RSSI class 0..3, or 255 if no usable reading. */
+  uint32 rssi_class = 3;
+}
+
+/*
  * Key native device metrics such as battery level
  */
 message DeviceMetrics {
@@ -36,6 +48,9 @@ message DeviceMetrics {
    * How long the device has been running since the last reboot (in seconds)
    */
   optional uint32 uptime_seconds = 5;
+
+  /* Top-3 senders this window when budget gossip is enabled. */
+  repeated TopSender top_senders = 6;
 }
 
 /*
@@ -666,6 +681,17 @@ message TrafficManagementStats {
    * Number of times router hop preservation was applied
    */
   uint32 router_hops_preserved = 7;
+
+  /* Drops while the sender was in probation and over its rate budget. */
+  uint32 probation_budget_drops = 8;
+  /* Relays skipped due to relay budget or a gossiped NO_RELAY bit. */
+  uint32 no_relay_skips = 9;
+  /* Probation windows shortened by an accepted KNOWN_SINCE vouch. */
+  uint32 attestation_promotions = 10;
+  /* NO_RELAY gossip packets this node emitted. */
+  uint32 no_relay_gossips_sent = 11;
+  /* Relays whose hop_limit was clamped by probation or congestion. */
+  uint32 relay_hop_caps_applied = 12;
 }
 
 /*


### PR DESCRIPTION
Additive-only wire format for the antispam trust ladder.

- `IdAttestation` on `ID_ATTESTATION_APP` (port 80): `KNOWN_SINCE`, `NO_RELAY`
- `TrafficManagementConfig` tags **15–31** (`no_relay_min_claimers` is 31)
- `TopSender` / `DeviceMetrics.top_senders` (max_count 3)
- `TrafficManagementStats` fields 8–12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for identity attestations and greylist gossip.
  - Added configurable traffic-management controls for probation, relay budgets, congestion limits, and gossip behavior.
  - Added telemetry for top packet senders and traffic-management activity.
  - Added metrics for budget drops, relay skips, attestation promotions, gossip packets, and hop-cap enforcement.
  - Limited reported top senders to three entries per device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->