### PR TITLE
Split soil and water chemistry out of EnvironmentMetrics into SoilWaterMetrics

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -249,80 +249,95 @@ message EnvironmentMetrics {
    */
   optional float lightning_distance_km = 41;
 
+  reserved 42 to 56;
+  reserved "soil_ph", "ph", "electrical_conductivity", "salinity", "nitrogen",
+           "phosphorus", "potassium", "dissolved_oxygen", "orp",
+           "chemical_oxygen_demand", "turbidity", "nitrate", "ammonium",
+           "biochemical_oxygen_demand", "solar_irradiance";
+}
+
+/*
+ * Soil and water probe metrics.
+ *
+ * Chemistry reported by soil probes (RS-485/SDI-12 NPK probes) and by
+ * water-quality sondes. Split out of EnvironmentMetrics so that message stays
+ * within the mesh payload budget.
+ */
+message SoilWaterMetrics {
   /*
    * Soil pH, 0-14
    */
-  optional float soil_ph = 42;
+  optional float soil_ph = 1;
 
   /*
    * pH of water or other solution, 0-14
    */
-  optional float ph = 43;
+  optional float ph = 2;
 
   /*
    * Electrical conductivity in mS/cm
    */
-  optional float electrical_conductivity = 44;
+  optional float electrical_conductivity = 3;
 
   /*
    * Salinity in mg/l
    */
-  optional float salinity = 45;
+  optional float salinity = 4;
 
   /*
    * Nitrogen concentration in mg/kg
    */
-  optional float nitrogen = 46;
+  optional float nitrogen = 5;
 
   /*
    * Phosphorus concentration in mg/kg
    */
-  optional float phosphorus = 47;
+  optional float phosphorus = 6;
 
   /*
    * Potassium concentration in mg/kg
    */
-  optional float potassium = 48;
+  optional float potassium = 7;
 
   /*
    * Dissolved oxygen in mg/l
    */
-  optional float dissolved_oxygen = 49;
+  optional float dissolved_oxygen = 8;
 
   /*
    * Oxidation-reduction potential (ORP) in mV
    */
-  optional float orp = 50;
+  optional float orp = 9;
 
   /*
    * Chemical oxygen demand in mg/l
    */
-  optional float chemical_oxygen_demand = 51;
+  optional float chemical_oxygen_demand = 10;
 
   /*
    * Turbidity in NTU
    */
-  optional float turbidity = 52;
+  optional float turbidity = 11;
 
   /*
    * Nitrate concentration in ppm
    */
-  optional float nitrate = 53;
+  optional float nitrate = 12;
 
   /*
    * Ammonium concentration in ppm
    */
-  optional float ammonium = 54;
+  optional float ammonium = 13;
 
   /*
    * Biochemical oxygen demand in mg/l
    */
-  optional float biochemical_oxygen_demand = 55;
+  optional float biochemical_oxygen_demand = 14;
 
   /*
    * Solar irradiance in W/m^2 (distinct from the radiation field's uR/h)
    */
-  optional float solar_irradiance = 56;
+  optional float solar_irradiance = 15;
 }
 
 /*
@@ -788,6 +803,11 @@ message Telemetry {
      * Traffic management statistics
      */
     TrafficManagementStats traffic_management_stats = 9;
+
+    /*
+     * Soil and water probe metrics
+     */
+    SoilWaterMetrics soil_water_metrics = 11;
   }
 }
 


### PR DESCRIPTION
`EnvironmentMetrics` reached 312 bytes, which exceeds the 233-byte
`DATA_PAYLOAD_LEN`. The 15 chemistry fields added at tags 42-56 are the
overflow. This moves them into their own `SoilWaterMetrics` message.

Nothing populates any of tags 42-56 in firmware today, and no tagged firmware
release contains them, so the move costs no deployed compatibility.

### Sizes

Generated with nanopb 0.4.9.1. The baseline regenerated to the current in-tree
constants exactly, so these are generator output rather than arithmetic.

| constant | before | after |
| --- | --- | --- |
| `EnvironmentMetrics_size` | 312 | 222 |
| `SoilWaterMetrics_size` | — | 75 |
| `HostMetrics_size` | 264 | 264 |
| `Telemetry_size` | 320 | 272 |

Struct sizes drop too: `EnvironmentMetrics` 424 to 304, `Telemetry` 432 to 312.
That is 120 bytes per cached node in the firmware NodeDB satellite map.

Fields are renumbered 1-15 so every float keeps a one-byte tag. The variant
costs 82 bytes inside `Telemetry`, leaving room to grow.

### Notes

- Oneof tag is **11**, not 10, to avoid colliding with #1030 which claims
  `cellular_metrics = 10`.
- One message rather than separate soil and water messages, so
  `electrical_conductivity`, `salinity` and temperature-adjacent fields are not
  duplicated. `soil_ph` and `ph` coexist deliberately: soil pH and solution pH
  are different measurands.
- `solar_irradiance` moves too. It is neither soil nor water, but it cannot stay
  behind: keeping it puts `EnvironmentMetrics` at 228 and the variant at 236,
  still over budget. Agronomy stations report it alongside soil chemistry.
- Both numbers and names are reserved. Reserving names prevents a later rebind
  from silently remapping data in reflection-based or JSON consumers.

### This does not fix the oversize-Telemetry bug

`Telemetry_size` lands at 272 because `HostMetrics` at 264 becomes the binding
variant. That is where it sat from #6836 until the recent pull. The encode
plumbing fix is tracked separately in meshtastic/firmware#11797.

### CI

`buf breaking` fails under the repo's current `breaking.use: [FILE]` policy with
15 field-deletion errors. Reserving numbers and names does not exempt deletions
under `FILE`; the reserved-tolerant rules live in `WIRE` and `WIRE_JSON`.
Verified locally: clean under `WIRE_JSON`, 15 errors under `FILE`. This needs a
`buf.yaml` policy decision before it can merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated soil and water telemetry reporting for chemistry and environmental measurements, including pH, salinity, nutrients, dissolved oxygen, turbidity, and solar irradiance.

- **Changes**
  - Soil and water measurements are now provided as a separate telemetry data type rather than being included with general environment metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Firmware side: meshtastic/firmware#11802 (draft until this merges).