### PR TITLE
Cap HostMetrics.user_string at 161 bytes so Telemetry fits the 233 byte payload

### DIFF
--- a/meshtastic/telemetry.options
+++ b/meshtastic/telemetry.options
@@ -16,4 +16,4 @@
 *HostMetrics.load1 int_size:16
 *HostMetrics.load5 int_size:16
 *HostMetrics.load15 int_size:16
-*HostMetrics.user_string max_size:200
+*HostMetrics.user_string max_size:161

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -250,10 +250,7 @@ message EnvironmentMetrics {
   optional float lightning_distance_km = 41;
 
   reserved 42 to 56;
-  reserved "soil_ph", "ph", "electrical_conductivity", "salinity", "nitrogen",
-           "phosphorus", "potassium", "dissolved_oxygen", "orp",
-           "chemical_oxygen_demand", "turbidity", "nitrate", "ammonium",
-           "biochemical_oxygen_demand", "solar_irradiance";
+  reserved "soil_ph", "ph", "electrical_conductivity", "salinity", "nitrogen", "phosphorus", "potassium", "dissolved_oxygen", "orp", "chemical_oxygen_demand", "turbidity", "nitrate", "ammonium", "biochemical_oxygen_demand", "solar_irradiance";
 }
 
 /*


### PR DESCRIPTION
HostMetrics is the only Telemetry variant that exceeds meshtastic_Constants_DATA_PAYLOAD_LEN, and capping user_string at 161 brings Telemetry_size to exactly 233, so an oversized encode can no longer be transmitted as an empty packet (meshtastic/firmware#11797).

Also collapses the EnvironmentMetrics reserved name list onto one line, which buf format was already failing on before this branch.