### PR TITLE
Generate Kotlin protos through Builder only

### DIFF
--- a/packages/kmp/build.gradle.kts
+++ b/packages/kmp/build.gradle.kts
@@ -107,9 +107,20 @@ wire {
         // nullable top-level properties, not sealed-class arms.
         boxOneOfsMinSize = 5000
 
-        // Skip defensive immutable copies of repeated/map fields on decode.
-        // Reduces allocations on high-frequency decode paths (mesh packets).
-        makeImmutableCopies = false
+        // Required by buildersOnly on Wire 6.4.7: with copies off, a repeated
+        // field initialises from the bare field name, which resolves to itself
+        // once the constructor takes a Builder - 32 uncompilable initialisers.
+        // Costs nothing on the hot paths, which have no repeated fields at all:
+        // MeshPacket, Data, Position, NodeInfo, Telemetry, FromRadio and ToRadio
+        // are all scalar/message only, so this touches config and bulk types.
+        makeImmutableCopies = true
+
+        // Construct through Builder only, so the generated types stay binary
+        // compatible across an added proto field. The all-args constructor and
+        // `copy()` encode every field in their signature, so a consumer compiled
+        // against a different `protobufs` version fails at runtime with
+        // NoSuchMethodError; a Builder property does not move.
+        buildersOnly = true
     }
 }
 


### PR DESCRIPTION
## Why

Wire's generated Kotlin types are binary compatible only at an exact `protobufs` version match, in either direction. A message compiles to one all-args synthetic constructor, so adding a single proto field moves that signature and any consumer compiled against a different copy of the artifact fails at runtime:

```
java.lang.NoSuchMethodError: 'void org.meshtastic.proto.NodeInfo.<init>(int, User, Position, float, int, DeviceMetrics, ...)'
```

Four things make it a bad failure. `buf breaking use:[FILE]` cannot catch it, because nothing about it is a wire break. Both POMs claim agreement, because the mismatch is bytecode against bytecode. Gradle actively selects the broken pair, since two pins on one classpath resolve to the higher. And it surfaces far from its cause, in the diagnosed case inside a coroutine, swallowed by an exception handler, visible only as a phone-API handshake that stopped dead after `my_info`.

It blocks shipping `meshtastic-node-kmp` as a product: `android` tracks an unreleased snapshot because that is where proto changes originate, node-kmp pins releases on purpose because the pin bump is its parity checkpoint, and those two positions cannot be reconciled across a published artifact.

Wire's `buildersOnly` fixes it permanently for additive changes, which is the only kind `buf breaking use:[FILE]` allows. A Builder is one property per field, so adding a proto field adds a property and moves no existing signature.

## Changes

🛠️ **Refactoring & Architecture**
- `buildersOnly = true` in `packages/kmp/build.gradle.kts`. Constructors become private, `copy()` is replaced by `newBuilder()`.
- `makeImmutableCopies` back to `true`, which `buildersOnly` forces on Wire 6.4.7. With copies off, a repeated field initialises from its own bare name once the constructor takes a `Builder`, which is a self-reference: 32 uncompilable initialisers across 20 types. Reproduces on Wire 7.0.0 too; worth an upstream report.

This repo has no Kotlin sources of its own, so that is the whole diff.

## The encoded bytes do not change

Proven twice rather than assumed.

**Statically**, across all 163 generated types: all **2532** `encodeWithTag`/`encodedSizeWithTag` (adapter, tag) pairs and all **1143** decode tag-to-adapter mappings are identical. Only the decode sink moves, from a local variable to a builder setter.

**At runtime**, in `TAKPacket-SDK`: its 47 golden `.bin` wire frames plus its `.pb` corpus regenerate byte-identical, all 103 files, and `compression-report.md` differs only in its `Generated:` date, so every compression ratio and byte count matches too.

## What consumers see

| | before | after |
| --- | ---: | ---: |
| `public fun copy(` | 142 | 0 |
| `private constructor` | 0 | 129 |
| real `newBuilder(): Builder` | 0 | 142 |
| `equals`/`hashCode`/`toString` | 142 | 142 |
| `data class` | 0 | 0 |
| `componentN()` | 0 | 0 |

The types were never data classes and `componentN` never existed, so no destructuring support is lost. Value semantics survive.

## Costs nothing on the hot paths

`makeImmutableCopies` was disabled here to cut allocations on "high-frequency decode paths (mesh packets)", but no hot-path type has a repeated field at all. `MeshPacket`, `Data`, `Position`, `NodeInfo`, `Telemetry`, `DeviceMetrics`, `FromRadio`, `ToRadio` and `User` are scalar and message only. The 20 affected types are config and bulk: `ChannelSet`, `Config`, `ModuleConfig`, `DeviceState`, `NodeDatabase`, `RouteDiscovery`, `NeighborInfo` and the TAK types.

## Landing

Draft until the consumer branches are reviewed together. No version bump is needed and none is proposed: this rides the next tag.

Merging this early breaks nobody. Maven Central releases are immutable and every Kotlin consumer pins an exact version, so each moves when it chooses. That is also why there is no parallel `protobufs-builders` artifact here; version numbers already do that job.

Consumer branches, all `chore/wire-builders-only`, all draft, all red in CI until this tags because their pins point at a local build:
- `TAKPacket-SDK` 19 sites, and a prerequisite for `android`, which consumes its published jar
- `meshtastic-node-kmp` 319 sites
- `meshtastic-sdk` 1078 sites
- `Meshtastic-Android` 2698 sites


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Repeated and map data is now safely copied during decoding, preventing unintended changes to decoded values.
  - Generated data types now use a consistent builder-based construction approach, improving compatibility when protocol fields are added.
- **Compatibility**
  - Existing generated models remain stable as schemas evolve, reducing the risk of breaking changes for consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->