### PR TITLE
Bump Wire to 7.0.0 and name the oneof mode

### DIFF
--- a/packages/kmp/build.gradle.kts
+++ b/packages/kmp/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("multiplatform") version "2.4.10"
     id("com.android.kotlin.multiplatform.library") version "9.3.2"
-    id("com.squareup.wire") version "6.4.7"
+    id("com.squareup.wire") version "7.0.0"
     id("com.vanniktech.maven.publish") version "0.37.0"
 }
 
@@ -64,7 +64,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api("com.squareup.wire:wire-runtime:6.4.7")
+                api("com.squareup.wire:wire-runtime:7.0.0")
             }
         }
     }
@@ -101,13 +101,16 @@ wire {
         includes = listOf("meshtastic.*")
 
         // Flatten oneof fields into nullable properties on the parent message
-        // class instead of generating intermediate sealed classes. All consumers
+        // class instead of intermediate sealed classes. All consumers
         // (Meshtastic-Android, TAKPacket-SDK) are written against this shape -
         // e.g. `packet.decoded`, `packet.chat`, `takPacketV2.shape` are all
-        // nullable top-level properties, not sealed-class arms.
-        boxOneOfsMinSize = 5000
+        // nullable top-level properties, not sealed-class arms. This used to be
+        // spelled `boxOneOfsMinSize = 5000`, a threshold set high enough that
+        // nothing could reach it; Wire 7 has a name for the intent. Generates
+        // byte-identical output to the old spelling.
+        oneofMode = "flat"
 
-        // Required by buildersOnly on Wire 6.4.7: with copies off, a repeated
+        // Required by buildersOnly, still on Wire 7.0.0: with copies off, a repeated
         // field initialises from the bare field name, which resolves to itself
         // once the constructor takes a Builder - 32 uncompilable initialisers.
         // Costs nothing on the hot paths, which have no repeated fields at all:


### PR DESCRIPTION
## Why

Three reasons, in order of weight. **Stacked on #1074** so the diff here is just the bump; retarget to `master` if that one is dropped.

### 1. Security, on a path that decodes untrusted input

6.4.7 carries fixed advisories:

- `GHSA-7xpr-hc2w-34m9` — negative lengths when skipping groups threw unchecked runtime exceptions instead of `ProtocolException`
- `GHSA-9rm7-3qhh-h2mc` — oversized lengths and fixed-width values past the current reader limit

Every Meshtastic client decodes frames that arrived over the air from a sender it cannot vouch for, and `Meshtastic-Android` already fuzzes exactly that path in `ReplayFuzzTest`. This is the reason to do it now rather than eventually.

### 2. It closes a firmware parity gap

42 generated types now route singular message fields through `decodeMessageOrMerge`. In `MeshPacket`:

```kotlin
// 6.4.7:  4 -> builder.decoded(Data.ADAPTER.decode(reader))
// 7.0.0:  4 -> builder.decoded(decodeMessageOrMerge(Data.ADAPTER, reader, builder.decoded))
```

`decoded` is a member of the `payload_variant` oneof. Measured all three decoders against the same eight bytes — a `MeshPacket` carrying field 4 twice, first `Data{portnum=1}`, then `Data{want_response=true}`:

| Decoder | `portnum` | `want_response` | Behaviour |
| --- | ---: | --- | --- |
| firmware nanopb 0.4.9.2 | 1 | true | **merge** |
| Wire 6.4.7 | 0 | true | **last-wins** |
| Wire 7.0.0 | 1 | true | **merge** |

**6.4.7 is the outlier.** 7.0.0 matches the firmware exactly, and the protobuf specification's rule for embedded messages with it. So this moves every Kotlin client onto firmware behaviour rather than away from it.

nanopb reaches merge by two independent mechanisms, both in `pb_decode.c`: `decode_field`'s `PB_HTYPE_ONEOF` case zeroes the union **only** when the incoming tag differs from the one already stored, and `pb_dec_submessage` passes `PB_DECODE_NOINIT` for any static non-repeated submessage. A repeated same-member occurrence therefore decodes into the struct that is already there.

### 3. `oneofMode` lets the config say what it means

`boxOneOfsMinSize = 5000` was never a threshold anyone meant to tune. It was a number set high enough that no oneof could reach it, and the comment admitted as much. Wire 7 adds `oneofMode`, so `"flat"` states the intent directly.

## Changes

🧹 **Chores**
- Wire plugin and `wire-runtime` 6.4.7 → 7.0.0.
- `boxOneOfsMinSize = 5000` → `oneofMode = "flat"`.
- Comment refreshed where it named 6.4.7.

## Testing performed

- `./gradlew build` in `packages/kmp`: green.
- **Encoded bytes unchanged**: all 2532 `encodeWithTag`/`encodedSizeWithTag` (adapter, tag) pairs identical to the 6.4.7 buildersOnly output.
- **`oneofMode = "flat"` is byte-identical to the old spelling**: generating with it and no `boxOneOfsMinSize` differs from `boxOneOfsMinSize = 5000` in **zero of 163 files**, with no boxed `OneOf<` references or sealed classes on either side. Worth checking rather than assuming, since the changelog says flat mode still *honours* `boxOneOfsMinSize`.
- **`buildersOnly` is unaffected by the bump**: 129 private constructors, 142 real `newBuilder()`, 0 `copy()`, identical to 6.4.7. #1074 needs no rework.

## Two things 7.0.0 does not fix

Both are repeated-field bugs, both reproduce on 7.0.0, and one upstream report covers them:

1. `buildersOnly` with `makeImmutableCopies = false` still emits 32 self-referential initialisers (`public val chunks: List<Int> = chunks`), so the coupling in #1074 stays.
2. Generated code still trips `UNNECESSARY_NOT_NULL_ASSERTION` nine times on `MutableList<Int>`/`<Float>` receivers, so `packages/kmp` keeps its `freeCompilerArgs` suppression. RC01's "warning-free under Kotlin 2.1" does not cover this — verified by removing the suppression and building with `allWarningsAsErrors`.

## Not applicable to us, checked rather than assumed

No `FieldMask`, no `redacted` fields, and no message named `Builder` in our schema, and the alpha02 CamelCase break only affects `oneofMode = sealed_class`. The Gradle 8.2+ floor is satisfied (we are on 9.7.1), the plugin no longer applying the Kotlin plugin transitively is fine because `packages/kmp` applies it itself, and the provider-backed `set(...)` migration does not reach the scalar options we set.

Other new 7.0 knobs left alone for now, noted so nobody has to go looking: `enumMode`, `mutableTypes`, `emitProtoReader32`, `nameSuffix`, `escapeKotlinKeywords`, `explicitStreamingCalls`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kotlin Multiplatform build configuration to use Wire 7.0.0.
  * Updated Wire code generation settings for compatibility with the newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->