### PR TITLE
docs: describe heard_on_current_lora as derived, not swept

### DIFF
--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -154,8 +154,12 @@ message NodeInfoLite {
 
   /*
    * Bitfield for storing booleans. See NODEINFO_BITFIELD_* in src/mesh/NodeDB.h.
-   * Bit 11 is NODEINFO_BITFIELD_HEARD_ON_CURRENT_LORA, mirrored on the wire as
-   * NodeInfo.heard_on_current_lora.
+   * Bit 11 is NODEINFO_BITFIELD_HAS_RF_HEAR, set once this node has been heard
+   * over our own radio and never cleared afterwards. Bits 12..23 hold a
+   * fingerprint of the LoRa slot it was last heard on. NodeInfo.heard_on_current_lora
+   * is derived from those two together, not stored: it is true when the node has
+   * been heard over RF and its recorded slot matches the slot the radio is
+   * currently committed to. Bits 24..31 are reserved.
    */
   uint32 bitfield = 13;
 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2083,14 +2083,20 @@ message NodeInfo {
   bool has_xeddsa_signed = 14;
 
   /*
-   * True if we have heard this node over RF since our current LoRa
-   * configuration took effect. Cleared for every node whenever the region,
-   * modem preset (or the custom bandwidth/spread factor/coding rate when
-   * use_preset is false), override_frequency, channel_num or the primary
-   * channel name changes - the frequency slot is derived from that name.
-   * Not set for nodes heard over MQTT, which reach us over the internet
-   * rather than over our own radio - see via_mqtt.
-   * LSB 11 of the bitfield
+   * True if we have heard this node over RF on the LoRa configuration the
+   * radio is using right now. Derived on the device rather than stored: each
+   * node records the frequency slot it was last heard on, and this reports
+   * whether that slot matches the one the radio is currently committed to.
+   * The slot covers the region, modem preset (or the custom bandwidth/spread
+   * factor/coding rate when use_preset is false), override_frequency,
+   * channel_num and the primary channel name.
+   * Because it is derived, leaving a configuration and returning to it
+   * restores the previous answers, so a client sweeping through presets to
+   * listen for traffic does not disturb them.
+   * Not set for nodes heard only over MQTT, which reach us over the internet
+   * rather than over our own radio - see via_mqtt - nor for nodes added as a
+   * shared contact, which have never been heard over RF at all.
+   * Derived from LSB 11 and bits 12..23 of NodeInfoLite.bitfield.
    */
   bool heard_on_current_lora = 15;
 }


### PR DESCRIPTION
# What does this PR do?

Corrects the doc comments on `NodeInfo.heard_on_current_lora` and
`NodeInfoLite.bitfield`. Comment-only, no field or wire change.

firmware [#11811](https://github.com/meshtastic/firmware/pull/11811) implements
the device half, and after review it dropped the sweep this text describes.
The current comments say two things that are no longer true:

- "Cleared for every node whenever the region ... changes". Nothing is cleared
  on a config change any more.
- "LSB 11 of the bitfield". Bit 11 is now `NODEINFO_BITFIELD_HAS_RF_HEAR`.

What the firmware actually does now: bit 11 is sticky once the node has been
heard over our own radio, bits 12..23 hold a fingerprint of the LoRa slot it
was heard on, and `heard_on_current_lora` is derived at read time by comparing
that stored slot against the slot the radio is committed to. Leaving a
configuration and returning to it restores the previous answers by itself,
which is what makes a client sweeping through presets (Mesh Discovery) safe.

Also records that nodes added as a shared contact read false, alongside
MQTT-only nodes. `addFromContact` never marks an RF hear, so they are in the
same position and clients need to know it.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions

`buf lint --path meshtastic` and `buf breaking --against master --path meshtastic`
both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the bitfield definitions for persistent RF-heard status, last-heard LoRa slot fingerprints, and reserved bits.
  * Explained how reported hearing status is derived from RF-heard information and the current LoRa slot.
  * Documented behavior for MQTT-only nodes, shared contacts, and nodes returning to a previously used configuration.
  * Confirmed that these updates clarify existing behavior without changing the protocol schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->