### PR TITLE
Add original_id field to storeforward message structure

### DIFF
--- a/meshtastic/storeforward.proto
+++ b/meshtastic/storeforward.proto
@@ -215,4 +215,9 @@ message StoreAndForward {
      */
     bytes text = 5;
   }
+  
+  /*
+   * Contains the original ID of the contained message.
+   */
+  uint32 original_id = 6;
 }

--- a/meshtastic/storeforward.proto
+++ b/meshtastic/storeforward.proto
@@ -215,7 +215,7 @@ message StoreAndForward {
      */
     bytes text = 5;
   }
-  
+
   /*
    * Contains the original ID of the contained message.
    */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for carrying the original message ID in store-and-forward messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->